### PR TITLE
Process crate names as Cargo does & use `index.html` as default target.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ changelog
 =========
 
 ## Unreleased
+### fixed
+- Closed [#15](https://github.com/thedodd/trunk/issues/15): ensure cargo package name is processed as cargo itself processes package names (`s/-/_/`).
+- Closed [#16](https://github.com/thedodd/trunk/issues/16): default to `index.html` as the default target for all CLI commands which expect a target. This matches the expectation of Seed & Yew.
 
 ## 0.1.2
 ### changed

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ pub fn main() {
 }
 ```
 
-Trunk uses a source HTML file to drive all asset building and bundling. Trunk also ships with a [built-in SASS/SCSS compiler](https://github.com/compass-rs/sass-rs), so let's get started with the following example. Copy this HTML to your cargo project's `src` dir at `src/index.html`:
+Trunk uses a source HTML file to drive all asset building and bundling. Trunk also ships with a [built-in SASS/SCSS compiler](https://github.com/compass-rs/sass-rs), so let's get started with the following example. Copy this HTML to the root of your project's repo as `index.html`:
 
 ```html
 <html>
@@ -54,7 +54,7 @@ Trunk uses a source HTML file to drive all asset building and bundling. Trunk al
 </html>
 ```
 
-`trunk build src/index.html` will produce the following HTML at `dist/index.html`, along with the compiled SCSS, WASM & the JS loader for the WASM:
+`trunk build` will produce the following HTML at `dist/index.html`, along with the compiled SCSS, WASM & the JS loader for the WASM:
 
 ```html
 <html>
@@ -72,15 +72,15 @@ The contents of your `dist` dir are now ready to be served on the web. But that'
 
 ## commands
 ### build
-`trunk build <src/index.html>` runs a cargo build targeting the wasm32 instruction set, runs `wasm-bindgen` on the built WASM, spawns asset build pipelines for any assets defined in the target `index.html`.
+`trunk build [index.html]` runs a cargo build targeting the wasm32 instruction set, runs `wasm-bindgen` on the built WASM, spawns asset build pipelines for any assets defined in the target `index.html`.
 
 Trunk leverages Rust's powerful concurrency primitives for maximum build speeds.
 
 ### watch
-`trunk watch <src/index.html>` does the same thing as `trunk build`, but watches the filesystem for changes, triggering new builds as changes are detected.
+`trunk watch [index.html]` does the same thing as `trunk build`, but watches the filesystem for changes, triggering new builds as changes are detected.
 
 ### serve
-`trunk serve <src/index.html>` does the same thing as `trunk watch`, but also spawns a web server.
+`trunk serve [index.html]` does the same thing as `trunk watch`, but also spawns a web server.
 
 ### clean
 `trunk clean` cleans up any build artifacts generated from earlier builds.

--- a/src/build.rs
+++ b/src/build.rs
@@ -441,8 +441,12 @@ impl CargoManifest {
         let manifest_path = get_cwd().await?.join("Cargo.toml");
         let manifest_raw = fs::read_to_string(&manifest_path).await
             .map_err(|err| anyhow!("error reading Cargo.toml file: {}", err))?;
-        let manifest: Self = toml::from_str(&manifest_raw)
+        let mut manifest: Self = toml::from_str(&manifest_raw)
             .map_err(|err| anyhow!("error parsing Cargo.toml: {}", err))?;
+
+        // Update the package name to match what its output name will be.
+        manifest.package.name = manifest.package.name.replace("-", "_");
+
         Ok(manifest)
     }
 }

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -11,7 +11,7 @@ use crate::common::parse_public_url;
 #[structopt(name="build")]
 pub struct Build {
     /// The index HTML file to drive the bundling process.
-    #[structopt(parse(from_os_str))]
+    #[structopt(default_value="index.html", parse(from_os_str))]
     target: PathBuf,
 
     /// Build in release mode.

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -16,7 +16,7 @@ use crate::watch::WatchSystem;
 #[structopt(name="serve")]
 pub struct Serve {
     /// The index HTML file to drive the bundling process.
-    #[structopt(parse(from_os_str))]
+    #[structopt(default_value="index.html", parse(from_os_str))]
     target: PathBuf,
 
     /// The port to serve on.

--- a/src/cmd/watch.rs
+++ b/src/cmd/watch.rs
@@ -11,7 +11,7 @@ use crate::watch::WatchSystem;
 #[structopt(name="watch")]
 pub struct Watch {
     /// The index HTML file to drive the bundling process.
-    #[structopt(parse(from_os_str))]
+    #[structopt(default_value="index.html", parse(from_os_str))]
     target: PathBuf,
 
     /// Build in release mode.


### PR DESCRIPTION
closes #15
closes #16

@martinkavik this should address the two issues you mentioned to me 🥳 🎉 🍻 