### PR TITLE
Added `--open` to `trunk serve` to control opening of browser tab.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,16 @@ changelog
 =========
 
 ## Unreleased
+### changed
+- `trunk serve` now takes the `--open` option to control whether or not a browser tab will be opened. Thanks @MartinKavik for the report.
+- The `trunk serve` listener info has been slightly updated. It continues to function as in previous releases. Thanks @MartinKavik for the report.
 
 ## 0.1.3
 ### fixed
 - Closed [#15](https://github.com/thedodd/trunk/issues/15): ensure cargo package name is processed as cargo itself processes package names (`s/-/_/`).
 - Closed [#16](https://github.com/thedodd/trunk/issues/16): default to `index.html` as the default target for all CLI commands which expect a target. This matches the expectation of Seed & Yew.
+
+Thanks @MartinKavik for reporting these items.
 
 ## 0.1.2
 ### changed

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -34,6 +34,9 @@ pub struct Serve {
     /// Additional paths to ignore.
     #[structopt(short, long, parse(from_os_str))]
     ignore: Option<Vec<PathBuf>>,
+    /// Open a browser tab once the initial build is complete.
+    #[structopt(long)]
+    open: bool,
 }
 
 impl Serve {
@@ -49,8 +52,10 @@ impl Serve {
         let server_handle = self.spawn_server()?;
 
         // Open the browser.
-        if let Err(err) = open::that(format!("http://localhost:{}", self.port)) {
-            eprintln!("error opening browser: {}", err);
+        if self.open {
+            if let Err(err) = open::that(format!("http://127.0.0.1:{}", self.port)) {
+                eprintln!("error opening browser: {}", err);
+            }
         }
 
         server_handle.await;
@@ -69,7 +74,7 @@ impl Serve {
         app.at(&self.public_url).serve_dir(self.dist.to_string_lossy().as_ref())?;
 
         // Listen and serve.
-        println!("📡 {}", format!("listening at http://{}", &listen_addr));
+        println!("📡 {}", format!("listening on port {}", &self.port));
         Ok(spawn(async move {
             if let Err(err) = app.listen(listen_addr).await {
                 eprintln!("{}", err);


### PR DESCRIPTION
closes #22