### PR TITLE
Emit warnings about invalid FS path references found in HTML.

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -75,7 +75,7 @@ impl Serve {
         app.at(&self.public_url).serve_dir(self.dist.to_string_lossy().as_ref())?;
 
         // Listen and serve.
-        println!("server running at {}", &http_addr);
+        println!("Server running at {}", &http_addr);
         Ok(spawn(async move {
             if let Err(err) = app.listen(listen_addr).await {
                 eprintln!("{}", err);


### PR DESCRIPTION
Also removed the use of emojis in output for now. Next PR will tackle
improving CLI output overall.

closes #18
related to #1