### PR TITLE
Allow reading values from sources other than CLI flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,14 +63,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,16 +436,32 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "3.0.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap_derive 3.0.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "os_str_bytes 2.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-error 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -867,6 +875,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,6 +957,15 @@ dependencies = [
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashbrown 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1244,6 +1266,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "parking"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1373,10 +1400,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro-error"
-version = "1.0.4"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro-error-attr 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-error-attr 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1385,11 +1412,13 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error-attr"
-version = "1.0.4"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn-mid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1793,30 +1822,8 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "structopt"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "clap 2.33.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt-derive 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro-error 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "subtle"
@@ -1834,6 +1841,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn-mid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tendril"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1841,6 +1858,14 @@ dependencies = [
  "futf 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "mac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf-8 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1959,6 +1984,7 @@ dependencies = [
  "async-process 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-std 1.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo_metadata 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 3.0.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "console 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1968,7 +1994,6 @@ dependencies = [
  "sass-rs 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "seahash 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tide 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2207,7 +2232,6 @@ dependencies = [
 "checksum aes-gcm 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "86f5007801316299f922a6198d1d09a0bae95786815d066d5880d13f7c45ead1"
 "checksum aes-soft 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4925647ee64e5056cf231608957ce7c81e12d6d6e316b9ce1404778cc1d35fa7"
 "checksum aesni 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d050d39b0b7688b3a3254394c3e30a9d66c41dcf9b05b0e2dbdc623f6505d264"
-"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)" = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
 "checksum arc-swap 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
 "checksum arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
@@ -2246,7 +2270,8 @@ dependencies = [
 "checksum cc 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)" = "66120af515773fb005778dc07c261bd201ec8ce50bd6e7144c927753fe013381"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chrono 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)" = "942f72db697d8767c22d46a598e01f2d3b475501ea43d0db4f16d90259182d0b"
-"checksum clap 2.33.3 (registry+https://github.com/rust-lang/crates.io-index)" = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+"checksum clap 3.0.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)" = "860643c53f980f0d38a5e25dfab6c3c93b2cb3aa1fe192643d17a293c6c41936"
+"checksum clap_derive 3.0.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fb51c9e75b94452505acd21d929323f5a5c6c4735a852adbd39ef5fb1b014f30"
 "checksum concurrent-queue 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
 "checksum console 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b1aacfaffdbff75be81c15a399b4bedf78aaefe840e8af1d299ac2ade885d2"
 "checksum constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
@@ -2292,6 +2317,7 @@ dependencies = [
 "checksum ghash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6e27f0689a6e15944bdce7e45425efb87eaa8ab0c6e87f11d0987a9133e2531"
 "checksum gimli 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
 "checksum gloo-timers 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "47204a46aaff920a1ea58b11d03dec6f704287d27561724a4631e450654a891f"
+"checksum hashbrown 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "00d63df3d41950fb462ed38308eea019113ad1508da725bbedcd0fa5a85ef5f7"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hermit-abi 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
 "checksum hkdf 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fe1149865383e4526a43aee8495f9a325f0b806c63ce6427d06336a590abbbc9"
@@ -2300,6 +2326,7 @@ dependencies = [
 "checksum http-types 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4daf8dc001485f4a32a7a17c54c67fa8a10340188f30ba87ac0fe1a9451e97"
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
+"checksum indexmap 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
 "checksum indicatif 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7baab56125e25686df467fe470785512329883aab42696d661247aca2a2896e4"
 "checksum infer 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6854dd77ddc4f9ba1a448f487e27843583d407648150426a30c2ea3a2c39490a"
 "checksum inotify 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f"
@@ -2337,6 +2364,7 @@ dependencies = [
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 "checksum opaque-debug 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 "checksum open 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c283bf0114efea9e42f1a60edea9859e8c47528eae09d01df4b29c1e489cc48"
+"checksum os_str_bytes 2.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2ac6fe3538f701e339953a3ebbe4f39941aababa8a3f6964635b24ab526daeac"
 "checksum parking 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "6cb300f271742d4a2a66c01b6b2fa0c83dfebd2e0bf11addb879a3547b4ed87c"
 "checksum parking 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
@@ -2354,8 +2382,8 @@ dependencies = [
 "checksum polyval 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9a50142b55ab3ed0e9f68dfb3709f1d90d29da24e91033f28b96330643107dc"
 "checksum ppv-lite86 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
 "checksum precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-"checksum proc-macro-error 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-"checksum proc-macro-error-attr 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+"checksum proc-macro-error 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
+"checksum proc-macro-error-attr 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
 "checksum proc-macro-hack 0.5.18 (registry+https://github.com/rust-lang/crates.io-index)" = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
 "checksum proc-macro-nested 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 "checksum proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
@@ -2404,12 +2432,12 @@ dependencies = [
 "checksum stdweb-internal-runtime 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 "checksum string_cache 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2940c75beb4e3bf3a494cef919a747a2cb81e52571e212bfbd185074add7208a"
 "checksum string_cache_codegen 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f24c8e5e19d22a726626f1a5e16fe15b132dcf21d10177fa5a45ce7962996b97"
-"checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-"checksum structopt 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc388d94ffabf39b5ed5fadddc40147cb21e605f53db6f8f36a625d27489ac5"
-"checksum structopt-derive 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "5e2513111825077552a6751dfad9e11ce0fba07d7276a3943a037d7e93e64c5f"
+"checksum strsim 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 "checksum subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
 "checksum syn 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "891d8d6567fe7c7f8835a3a98af4208f3846fba258c1bc3c31d6e506239f11f9"
+"checksum syn-mid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 "checksum tendril 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "707feda9f2582d5d680d733e38755547a3e8fb471e7ba11452ecfd9ce93a5d3b"
+"checksum termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
 "checksum terminal_size 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9a14cd9f8c72704232f0bfc8455c0e861f0ad4eb60cc9ec8a170e231414c1e13"
 "checksum termios 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6f0fcee7b24a25675de40d5bb4de6e41b0df07bc9856295e7e2b3a3600c400c2"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ notify = "4.0.15"
 open = "1.4.0"
 sass-rs = "0.2.2"
 seahash = "4.0.1"
-serde = { version="1", features=["derive"] }
+serde = { version="1.0.97", features=["derive"] }
 clap = "3.0.0-beta.1"
 tide = "0.13.0"
 toml = "0.5.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,6 @@ open = "1.4.0"
 sass-rs = "0.2.2"
 seahash = "4.0.1"
 serde = { version="1", features=["derive"] }
-structopt = "0.3.16"
+clap = "3.0.0-beta.1"
 tide = "0.13.0"
 toml = "0.5.6"

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -11,19 +11,19 @@ use crate::common::parse_public_url;
 #[clap(name="build")]
 pub struct Build {
     /// The index HTML file to drive the bundling process.
-    #[clap(default_value="index.html", parse(from_os_str))]
+    #[clap(default_value="index.html", parse(from_os_str), env="TARGET")]
     target: PathBuf,
     /// Build in release mode.
-    #[clap(long)]
+    #[clap(long, env="RELEASE")]
     release: bool,
     /// The output dir for all final assets.
-    #[clap(short, long, default_value="dist", parse(from_os_str))]
+    #[clap(short, long, default_value="dist", parse(from_os_str), env="DIST")]
     dist: PathBuf,
     /// The public URL from which assets are to be served.
-    #[clap(long, default_value="/", parse(from_str=parse_public_url))]
+    #[clap(long, default_value="/", parse(from_str=parse_public_url), env="PUBLIC_URL")]
     public_url: String,
     /// Path to Cargo.toml.
-    #[clap(long="manifest-path", parse(from_os_str))]
+    #[clap(long="manifest-path", parse(from_os_str), env="MANIFEST_PATH")]
     manifest: Option<PathBuf>,
 }
 

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -5,36 +5,59 @@ use clap::Clap;
 
 use crate::build::{BuildSystem, CargoMetadata};
 use crate::common::parse_public_url;
+use crate::config::Config;
 
 /// Build the Rust WASM app and all of its assets.
 #[derive(Clap)]
 #[clap(name="build")]
 pub struct Build {
-    /// The index HTML file to drive the bundling process.
-    #[clap(default_value="index.html", parse(from_os_str), env="TARGET")]
-    target: PathBuf,
+    /// The index HTML file to drive the bundling process. [default: index.html]
+    #[clap(parse(from_os_str), env="TARGET")]
+    target: Option<PathBuf>,
     /// Build in release mode.
     #[clap(long, env="RELEASE")]
     release: bool,
-    /// The output dir for all final assets.
-    #[clap(short, long, default_value="dist", parse(from_os_str), env="DIST")]
-    dist: PathBuf,
-    /// The public URL from which assets are to be served.
-    #[clap(long, default_value="/", parse(from_str=parse_public_url), env="PUBLIC_URL")]
-    public_url: String,
+    /// The output dir for all final assets. [default: dist]
+    #[clap(short, long, parse(from_os_str), env="DIST")]
+    dist: Option<PathBuf>,
+    /// The public URL from which assets are to be served. [default: /]
+    #[clap(long, parse(from_str=parse_public_url), env="PUBLIC_URL")]
+    public_url: Option<String>,
     /// Path to Cargo.toml.
     #[clap(long="manifest-path", parse(from_os_str), env="MANIFEST_PATH")]
     manifest: Option<PathBuf>,
 }
 
 impl Build {
-    pub async fn run(self) -> Result<()> {
-        let manifest = CargoMetadata::new(&self.manifest).await?;
+    pub async fn run(self, config: Config) -> Result<()> {
+        let conf = BuildConfig::new(self, config);
+
+        let manifest = CargoMetadata::new(&conf.manifest).await?;
         let mut system = BuildSystem::new(
-            manifest, self.target.clone(), self.release,
-            self.dist.clone(), self.public_url.clone(),
+            manifest, conf.target.clone(), conf.release,
+            conf.dist.clone(), conf.public_url.clone(),
         ).await?;
         system.build().await?;
         Ok(())
+    }
+}
+
+struct BuildConfig {
+    target: PathBuf,
+    release: bool,
+    dist: PathBuf,
+    public_url: String,
+    manifest: Option<PathBuf>,
+}
+
+impl BuildConfig {
+    fn new(build: Build, toml_config: Config) -> Self {
+        BuildConfig {
+            target: build.target.unwrap_or(toml_config.html_target),
+            release: build.release || toml_config.release,
+            dist: build.dist.unwrap_or(toml_config.dist),
+            public_url: build.public_url.unwrap_or(toml_config.public_url),
+            manifest: if let Some(manifest) = build.manifest { Some(manifest) } else { toml_config.manifest },
+        }
     }
 }

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -1,30 +1,29 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use structopt::StructOpt;
+use clap::Clap;
 
 use crate::build::{BuildSystem, CargoMetadata};
 use crate::common::parse_public_url;
 
 /// Build the Rust WASM app and all of its assets.
-#[derive(StructOpt)]
-#[structopt(name="build")]
+#[derive(Clap)]
+#[clap(name="build")]
 pub struct Build {
     /// The index HTML file to drive the bundling process.
-    #[structopt(default_value="index.html", parse(from_os_str))]
+    #[clap(default_value="index.html", parse(from_os_str))]
     target: PathBuf,
-
     /// Build in release mode.
-    #[structopt(long)]
+    #[clap(long)]
     release: bool,
     /// The output dir for all final assets.
-    #[structopt(short, long, default_value="dist", parse(from_os_str))]
+    #[clap(short, long, default_value="dist", parse(from_os_str))]
     dist: PathBuf,
     /// The public URL from which assets are to be served.
-    #[structopt(long, default_value="/", parse(from_str=parse_public_url))]
+    #[clap(long, default_value="/", parse(from_str=parse_public_url))]
     public_url: String,
     /// Path to Cargo.toml.
-    #[structopt(long="manifest-path", parse(from_os_str))]
+    #[clap(long="manifest-path", parse(from_os_str))]
     manifest: Option<PathBuf>,
 }
 

--- a/src/cmd/clean.rs
+++ b/src/cmd/clean.rs
@@ -4,23 +4,25 @@ use anyhow::Result;
 use async_std::fs;
 use async_process::{Command, Stdio};
 use clap::Clap;
+use crate::config::Config;
 
 /// Clean output artifacts.
 #[derive(Clap)]
 #[clap(name="clean")]
 pub struct Clean {
-    /// The target asset dir.
-    #[clap(short, long, default_value="dist", parse(from_os_str), env="DIST")]
-    dist: PathBuf,
+    /// The target asset dir. [default: dist]
+    #[clap(short, long, parse(from_os_str), env="DIST")]
+    dist: Option<PathBuf>,
     /// Optionally perform a `cargo clean`.
     #[clap(short, long, env="CARGO_CLEAN")]
     cargo: bool,
 }
 
 impl Clean {
-    pub async fn run(self) -> Result<()> {
-        let _ = fs::remove_dir_all(&self.dist).await;
-        if self.cargo {
+    pub async fn run(self, config: Config) -> Result<()> {
+        let conf = CleanConfig::new(self, config);
+        let _ = fs::remove_dir_all(&conf.dist).await;
+        if conf.cargo {
             let output = Command::new("cargo")
                 .arg("clean")
                 .stdout(Stdio::piped())
@@ -32,5 +34,19 @@ impl Clean {
             }
         }
         Ok(())
+    }
+}
+
+struct CleanConfig {
+    dist: PathBuf,
+    cargo: bool,
+}
+
+impl CleanConfig {
+    fn new(clean: Clean, toml_config: Config) -> Self {
+        CleanConfig {
+            dist: clean.dist.unwrap_or(toml_config.dist),
+            cargo: clean.cargo || toml_config.clean.run_cargo_clean
+        }
     }
 }

--- a/src/cmd/clean.rs
+++ b/src/cmd/clean.rs
@@ -10,10 +10,10 @@ use clap::Clap;
 #[clap(name="clean")]
 pub struct Clean {
     /// The target asset dir.
-    #[clap(short, long, default_value="dist", parse(from_os_str))]
+    #[clap(short, long, default_value="dist", parse(from_os_str), env="DIST")]
     dist: PathBuf,
     /// Optionally perform a `cargo clean`.
-    #[clap(short, long)]
+    #[clap(short, long, env="CARGO_CLEAN")]
     cargo: bool,
 }
 

--- a/src/cmd/clean.rs
+++ b/src/cmd/clean.rs
@@ -3,17 +3,17 @@ use std::path::PathBuf;
 use anyhow::Result;
 use async_std::fs;
 use async_process::{Command, Stdio};
-use structopt::StructOpt;
+use clap::Clap;
 
 /// Clean output artifacts.
-#[derive(StructOpt)]
-#[structopt(name="clean")]
+#[derive(Clap)]
+#[clap(name="clean")]
 pub struct Clean {
     /// The target asset dir.
-    #[structopt(short, long, default_value="dist", parse(from_os_str))]
+    #[clap(short, long, default_value="dist", parse(from_os_str))]
     dist: PathBuf,
     /// Optionally perform a `cargo clean`.
-    #[structopt(short, long)]
+    #[clap(short, long)]
     cargo: bool,
 }
 

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -6,7 +6,7 @@ use async_std::fs;
 use async_std::task::{spawn, spawn_local, JoinHandle};
 use console::Emoji;
 use indicatif::ProgressBar;
-use structopt::StructOpt;
+use clap::Clap;
 use tide::{Request, Response, Middleware, Next, StatusCode};
 use tide::http::mime;
 
@@ -14,33 +14,33 @@ use crate::common::parse_public_url;
 use crate::watch::WatchSystem;
 
 /// Build the Rust WASM app and all of its assets.
-#[derive(StructOpt)]
-#[structopt(name="serve")]
+#[derive(Clap)]
+#[clap(name="serve")]
 pub struct Serve {
     /// The index HTML file to drive the bundling process.
-    #[structopt(default_value="index.html", parse(from_os_str))]
+    #[clap(default_value="index.html", parse(from_os_str))]
     target: PathBuf,
 
     /// The port to serve on.
-    #[structopt(long, default_value="8080")]
+    #[clap(long, default_value="8080")]
     port: u16,
     /// Build in release mode.
-    #[structopt(long)]
+    #[clap(long)]
     release: bool,
     /// The output dir for all final assets.
-    #[structopt(short, long, default_value="dist", parse(from_os_str))]
+    #[clap(short, long, default_value="dist", parse(from_os_str))]
     dist: PathBuf,
     /// The public URL from which assets are to be served.
-    #[structopt(long, default_value="/", parse(from_str=parse_public_url))]
+    #[clap(long, default_value="/", parse(from_str=parse_public_url))]
     public_url: String,
     /// Additional paths to ignore.
-    #[structopt(short, long, parse(from_os_str))]
+    #[clap(short, long, parse(from_os_str))]
     ignore: Option<Vec<PathBuf>>,
     /// Open a browser tab once the initial build is complete.
-    #[structopt(long)]
+    #[clap(long)]
     open: bool,
     /// Path to Cargo.toml.
-    #[structopt(long="manifest-path", parse(from_os_str))]
+    #[clap(long="manifest-path", parse(from_os_str))]
     manifest: Option<PathBuf>,
 }
 

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -18,29 +18,28 @@ use crate::watch::WatchSystem;
 #[clap(name="serve")]
 pub struct Serve {
     /// The index HTML file to drive the bundling process.
-    #[clap(default_value="index.html", parse(from_os_str))]
+    #[clap(default_value="index.html", parse(from_os_str), env="TARGET")]
     target: PathBuf,
-
     /// The port to serve on.
-    #[clap(long, default_value="8080")]
+    #[clap(long, default_value="8080", env="PORT")]
     port: u16,
     /// Build in release mode.
     #[clap(long)]
     release: bool,
     /// The output dir for all final assets.
-    #[clap(short, long, default_value="dist", parse(from_os_str))]
+    #[clap(short, long, default_value="dist", parse(from_os_str), env="DIST")]
     dist: PathBuf,
     /// The public URL from which assets are to be served.
-    #[clap(long, default_value="/", parse(from_str=parse_public_url))]
+    #[clap(long, default_value="/", parse(from_str=parse_public_url), env="PUBLIC_URL")]
     public_url: String,
     /// Additional paths to ignore.
-    #[clap(short, long, parse(from_os_str))]
+    #[clap(short, long, parse(from_os_str), env="IGNORE_PATHS")]
     ignore: Option<Vec<PathBuf>>,
     /// Open a browser tab once the initial build is complete.
-    #[clap(long)]
+    #[clap(long, env="OPEN")]
     open: bool,
     /// Path to Cargo.toml.
-    #[clap(long="manifest-path", parse(from_os_str))]
+    #[clap(long="manifest-path", parse(from_os_str), env="MANIFEST_PATH")]
     manifest: Option<PathBuf>,
 }
 

--- a/src/cmd/watch.rs
+++ b/src/cmd/watch.rs
@@ -1,33 +1,33 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use structopt::StructOpt;
+use clap::Clap;
 
 use crate::common::parse_public_url;
 use crate::watch::WatchSystem;
 
 /// Watch the Rust WASM app and execute builds as changes are detected.
-#[derive(StructOpt)]
-#[structopt(name="watch")]
+#[derive(Clap)]
+#[clap(name="watch")]
 pub struct Watch {
     /// The index HTML file to drive the bundling process.
-    #[structopt(default_value="index.html", parse(from_os_str))]
+    #[clap(default_value="index.html", parse(from_os_str))]
     target: PathBuf,
 
     /// Build in release mode.
-    #[structopt(long)]
+    #[clap(long)]
     release: bool,
     /// The output dir for all final assets.
-    #[structopt(short, long, default_value="dist", parse(from_os_str))]
+    #[clap(short, long, default_value="dist", parse(from_os_str))]
     dist: PathBuf,
     /// The public URL from which assets are to be served.
-    #[structopt(long, default_value="/", parse(from_str=parse_public_url))]
+    #[clap(long, default_value="/", parse(from_str=parse_public_url))]
     public_url: String,
     /// Additional paths to ignore.
-    #[structopt(short, long, parse(from_os_str))]
+    #[clap(short, long, parse(from_os_str))]
     ignore: Option<Vec<PathBuf>>,
     /// Path to Cargo.toml.
-    #[structopt(long="manifest-path", parse(from_os_str))]
+    #[clap(long="manifest-path", parse(from_os_str))]
     manifest: Option<PathBuf>,
 }
 

--- a/src/cmd/watch.rs
+++ b/src/cmd/watch.rs
@@ -5,39 +5,63 @@ use clap::Clap;
 
 use crate::common::parse_public_url;
 use crate::watch::WatchSystem;
+use crate::config::Config;
 
 /// Watch the Rust WASM app and execute builds as changes are detected.
 #[derive(Clap)]
-#[clap(name="watch")]
+#[clap(name = "watch")]
 pub struct Watch {
-    /// The index HTML file to drive the bundling process.
-    #[clap(default_value="index.html", parse(from_os_str), env="TARGET")]
-    target: PathBuf,
+    /// The index HTML file to drive the bundling process. [default: index.html]
+    #[clap(parse(from_os_str), env = "TARGET")]
+    target: Option<PathBuf>,
     /// Build in release mode.
-    #[clap(long, env="RELEASE")]
+    #[clap(long, env = "RELEASE")]
     release: bool,
-    /// The output dir for all final assets.
-    #[clap(short, long, default_value="dist", parse(from_os_str), env="DIST")]
-    dist: PathBuf,
-    /// The public URL from which assets are to be served.
-    #[clap(long, default_value="/", parse(from_str=parse_public_url), env="PUBLIC_URL")]
-    public_url: String,
+    /// The output dir for all final assets. [default: dist]
+    #[clap(short, long, parse(from_os_str), env = "DIST")]
+    dist: Option<PathBuf>,
+    /// The public URL from which assets are to be served. [default: /]
+    #[clap(long, parse(from_str = parse_public_url), env = "PUBLIC_URL")]
+    public_url: Option<String>,
     /// Additional paths to ignore.
-    #[clap(short, long, parse(from_os_str), env="IGNORE")]
+    #[clap(short, long, parse(from_os_str), env = "IGNORED_PATHS")]
     ignore: Option<Vec<PathBuf>>,
     /// Path to Cargo.toml.
-    #[clap(long="manifest-path", parse(from_os_str), env="MANIFEST_PATH")]
+    #[clap(long = "manifest-path", parse(from_os_str), env = "MANIFEST_PATH")]
     manifest: Option<PathBuf>,
 }
 
 impl Watch {
-    pub async fn run(self) -> Result<()> {
+    pub async fn run(self, config: Config) -> Result<()> {
+        let conf = WatchConfig::new(self, config);
         let mut system = WatchSystem::new(
-            self.target, self.release, self.dist, self.public_url,
-            self.ignore.unwrap_or_default(), self.manifest,
+            conf.target, conf.release, conf.dist, conf.public_url,
+            conf.ignored_paths.unwrap_or_default(), conf.manifest,
         ).await?;
         system.build().await;
         system.run().await;
         Ok(())
+    }
+}
+
+struct WatchConfig {
+    target: PathBuf,
+    release: bool,
+    dist: PathBuf,
+    public_url: String,
+    ignored_paths: Option<Vec<PathBuf>>,
+    manifest: Option<PathBuf>,
+}
+
+impl WatchConfig {
+    fn new(watch: Watch, toml_config: Config) -> Self {
+        let target = if let Some(target) = watch.target { target } else { toml_config.html_target };
+        let release = watch.release || toml_config.release;
+        let dist = if let Some(dist) = watch.dist { dist } else { toml_config.dist };
+        let public_url = if let Some(pub_url) = watch.public_url { pub_url } else { toml_config.public_url };
+        let ignored_paths = if let Some(ignores) = watch.ignore { Some(ignores) } else { toml_config.watch.ignored_paths };
+        let manifest = if let Some(manifest) = watch.manifest { Some(manifest) } else { toml_config.manifest };
+
+        Self { target, release, dist, public_url, ignored_paths, manifest }
     }
 }

--- a/src/cmd/watch.rs
+++ b/src/cmd/watch.rs
@@ -11,23 +11,22 @@ use crate::watch::WatchSystem;
 #[clap(name="watch")]
 pub struct Watch {
     /// The index HTML file to drive the bundling process.
-    #[clap(default_value="index.html", parse(from_os_str))]
+    #[clap(default_value="index.html", parse(from_os_str), env="TARGET")]
     target: PathBuf,
-
     /// Build in release mode.
-    #[clap(long)]
+    #[clap(long, env="RELEASE")]
     release: bool,
     /// The output dir for all final assets.
-    #[clap(short, long, default_value="dist", parse(from_os_str))]
+    #[clap(short, long, default_value="dist", parse(from_os_str), env="DIST")]
     dist: PathBuf,
     /// The public URL from which assets are to be served.
-    #[clap(long, default_value="/", parse(from_str=parse_public_url))]
+    #[clap(long, default_value="/", parse(from_str=parse_public_url), env="PUBLIC_URL")]
     public_url: String,
     /// Additional paths to ignore.
-    #[clap(short, long, parse(from_os_str))]
+    #[clap(short, long, parse(from_os_str), env="IGNORE")]
     ignore: Option<Vec<PathBuf>>,
     /// Path to Cargo.toml.
-    #[clap(long="manifest-path", parse(from_os_str))]
+    #[clap(long="manifest-path", parse(from_os_str), env="MANIFEST_PATH")]
     manifest: Option<PathBuf>,
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,0 +1,12 @@
+mod models;
+pub use models::*;
+use std::path::PathBuf;
+
+
+pub fn read_config(path: Option<PathBuf>) -> Config {
+    let path = path.unwrap_or(PathBuf::from("Trunk.toml"));
+    let toml_string = std::fs::read_to_string(path).expect("Reading TOML config file failed");
+
+    toml::from_str(&toml_string).expect("Parsing TOML config file failed")
+}
+

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -1,0 +1,49 @@
+use std::path::PathBuf;
+use serde::{Deserialize};
+
+// Working around https://github.com/serde-rs/serde/issues/368
+fn default_as_true() -> bool { true }
+fn default_as_false() -> bool { true }
+fn default_port() -> u16 { 8080 }
+fn default_html_target() -> PathBuf { PathBuf::from("index.html") }
+fn default_dist() -> PathBuf { PathBuf::from("dist") }
+fn default_pub_url() -> String { "/".to_string() }
+
+#[derive(Deserialize)]
+pub struct Config {
+    #[serde(default = "default_html_target")]
+    pub html_target: PathBuf,
+    #[serde(default = "default_as_true")]
+    pub release: bool,
+    #[serde(default = "default_dist")]
+    pub dist: PathBuf,
+    #[serde(default)]
+    pub manifest: Option<PathBuf>,
+    #[serde(default = "default_pub_url")]
+    pub public_url: String,
+    pub clean: CleanArgs,
+    pub serve: ServeArgs,
+    pub watch: WatchArgs,
+}
+
+#[derive(Deserialize)]
+pub struct CleanArgs {
+    #[serde(default = "default_as_false")]
+    pub run_cargo_clean: bool
+}
+
+#[derive(Deserialize)]
+pub struct ServeArgs {
+    #[serde(default = "default_as_false")]
+    pub open_browser: bool,
+    #[serde(default)]
+    pub ignored_paths: Option<Vec<PathBuf>>,
+    #[serde(default = "default_port")]
+    pub port: u16
+}
+
+#[derive(Deserialize)]
+pub struct WatchArgs {
+    #[serde(default)]
+    pub ignored_paths: Option<Vec<PathBuf>>,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,11 +4,11 @@ mod common;
 mod watch;
 
 use anyhow::Result;
-use structopt::StructOpt;
+use clap::Clap;
 
 #[async_std::main]
 async fn main() -> Result<()> {
-    let cli = Trunk::from_args();
+    let cli = Trunk::parse();
     if let Err(err) = cli.run().await {
         eprintln!("{}", err.to_string());
     }
@@ -16,10 +16,10 @@ async fn main() -> Result<()> {
 }
 
 /// Build, bundle & ship your Rust WASM application to the web.
-#[derive(StructOpt)]
-#[structopt(name="trunk")]
+#[derive(Clap)]
+#[clap(name="trunk")]
 struct Trunk {
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     action: TrunkSubcommands
 }
 
@@ -34,7 +34,7 @@ impl Trunk {
     }
 }
 
-#[derive(StructOpt)]
+#[derive(Clap)]
 enum TrunkSubcommands {
     Build(cmd::build::Build),
     Clean(cmd::clean::Clean),

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,14 +2,17 @@ mod build;
 mod cmd;
 mod common;
 mod watch;
+mod config;
 
 use anyhow::Result;
 use clap::Clap;
+use config::{read_config, Config};
 
 #[async_std::main]
 async fn main() -> Result<()> {
     let cli = Trunk::parse();
-    if let Err(err) = cli.run().await {
+    let config = read_config(None);
+    if let Err(err) = cli.run(config).await {
         eprintln!("{}", err.to_string());
     }
     Ok(())
@@ -24,12 +27,12 @@ struct Trunk {
 }
 
 impl Trunk {
-    pub async fn run(self) -> Result<()> {
+    pub async fn run(self, config: Config) -> Result<()> {
         match self.action {
-            TrunkSubcommands::Build(inner) => inner.run().await,
-            TrunkSubcommands::Clean(inner) => inner.run().await,
-            TrunkSubcommands::Serve(inner) => inner.run().await,
-            TrunkSubcommands::Watch(inner) => inner.run().await,
+            TrunkSubcommands::Build(inner) => inner.run(config).await,
+            TrunkSubcommands::Clean(inner) => inner.run(config).await,
+            TrunkSubcommands::Serve(inner) => inner.run(config).await,
+            TrunkSubcommands::Watch(inner) => inner.run(config).await,
         }
     }
 }


### PR DESCRIPTION
This PR adds support for reading values from
- Environmental variables
- `Trunk.toml` file

In addition to that, I also switched from `structopt` to `clap` 3 beta