### PR TITLE
Fix a regression in the server.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog follows the patterns described here: https://keepachangelog.com/e
 
 ## Unreleased
 
+## 0.5.1
+### fixed
+- Closes [#55](https://github.com/thedodd/trunk/issues/55): Fixed a regression in the server where the middleware was declared after the handler, and was thus not working as needed. Putting the middleware first fixes the issue.
+
 ## 0.5.0
 ### added
 - Added support for proxying requests to arbitrary HTTP backends.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trunk"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2018"
 description = "Build, bundle & ship your Rust WASM application to the web."
 license = "MIT/Apache-2.0"

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -62,8 +62,8 @@ impl ServeSystem {
         // Build app.
         tide::log::with_level(tide::log::LevelFilter::Error);
         let mut app = tide::with_state(State { index });
-        app.at(&cfg.watch.build.public_url)
-            .with(IndexHtmlMiddleware)
+        app.with(IndexHtmlMiddleware)
+            .at(&cfg.watch.build.public_url)
             .serve_dir(cfg.watch.build.dist.to_string_lossy().as_ref())?;
 
         // Build proxies.


### PR DESCRIPTION
This fixes a regression in the 0.5.0 release where the index.html file
was not being served as a fallback.

closes #55
closes yewstack/yew#1587