### PR TITLE
Write public URL to marked base elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This changelog follows the patterns described here: https://keepachangelog.com/e
 
 ## Unreleased
 
+### added
+- Support for writing the public url (`--public-url`) to the HTML output. [#59]
+
 ## 0.5.1
 ### fixed
 - Closes [#55](https://github.com/thedodd/trunk/issues/55): Fixed a regression in the server where the middleware was declared after the handler, and was thus not working as needed. Putting the middleware first fixes the issue.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This changelog follows the patterns described here: https://keepachangelog.com/e
 ## Unreleased
 
 ### added
-- Support for writing the public URL (`--public-url`) to the HTML output. [#59]
+- Support for writing the public URL (`--public-url`) to the HTML output. ([#59](https://github.com/thedodd/trunk/issues/55))
 
 ## 0.5.1
 ### fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This changelog follows the patterns described here: https://keepachangelog.com/e
 ## Unreleased
 
 ### added
-- Support for writing the public url (`--public-url`) to the HTML output. [#59]
+- Support for writing the public URL (`--public-url`) to the HTML output. [#59]
 
 ## 0.5.1
 ### fixed

--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ This will allow your WASM application to reference images directly from the `dis
 
 **NOTE:** as Trunk continues to mature, we will find better ways to include images and other resources. Hashing content for cache control is great, we just need to find a nice pattern to work with images referenced in Rust components. Please contribute to the discussion over in [trunk#9](https://github.com/thedodd/trunk/issues/9)! See you there.
 
+### directives
+You can instruct Trunk to write the URL passed to `--public-url` to the HTML output by adding this to your `<head>`: `<base data-trunk-public-url/>`.
+Trunk will set the `href` attribute of the element to the public URL. This changes the behavior of relative URLs to be relative to the public URL instead of the current location.
+You can also access this value at runtime using `document.baseURI` which is useful for apps that need to know what base URL they're hosted on (eg. for routing).
+
 ## configuration
 Trunk supports a layered config system. At the base, a config file can encapsulate project specific defaults, paths, ports and other config. Environment variables can be used to overwrite config file values. Lastly, CLI arguments / options take final precedence.
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -18,6 +18,7 @@ use crate::config::RtcBuild;
 
 const TRUNK_ID: &str = "__trunk-id";
 const HREF_ATTR: &str = "href";
+const PUBLIC_URL_MARKER_ATTR: &str = "data-trunk-public-url";
 const SNIPPETS_DIR: &str = "snippets";
 
 /// A system used for building a Rust WASM app & bundling its assets.
@@ -125,10 +126,21 @@ impl BuildSystem {
         self.finalize_asset_pipelines(&mut target_html).await;
         self.insert_wasm_module(&wasm_bindgen_output, &mut target_html);
 
+        // Finalize document
+        self.finalize_html(&mut target_html);
+
         // Assemble a new output index.html file.
         let output_html = target_html.html(); // TODO: prettify this output.
         fs::write(format!("{}/index.html", self.cfg.dist.display()), output_html.as_bytes()).await?;
         Ok(())
+    }
+
+    /// Prepare the document for final output
+    fn finalize_html(&self, target_html: &mut Document) {
+        // write public_url to base elements
+        let mut base_elements = target_html.select(&format!("html head base[{}]", PUBLIC_URL_MARKER_ATTR));
+        base_elements.remove_attr(PUBLIC_URL_MARKER_ATTR);
+        base_elements.set_attr("href", &self.cfg.public_url);
     }
 
     /// Finalize asset pipelines & prep the DOM for final output.

--- a/src/build.rs
+++ b/src/build.rs
@@ -388,7 +388,8 @@ impl BuildSystem {
         })
     }
 
-    /// Spawn a concurrent build pipeline which simply copies the source to the destination, unchanged.
+    /// Spawn a concurrent build pipeline which simply copies the source to the destination,
+    /// unchanged.
     fn spawn_copy_pipeline(&mut self, asset: AssetFile, hash: bool, remove: bool) -> JoinHandle<Result<AssetPipelineOutput>> {
         let dist = self.cfg.dist.clone();
         spawn(async move {
@@ -413,7 +414,6 @@ impl BuildSystem {
     }
 }
 
-//////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
 /// An asset type descriptor extracted from the source HTML.
@@ -486,7 +486,6 @@ impl AssetFile {
 }
 
 //////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////
 
 /// The output of an asset pipeline.
 pub struct AssetPipelineOutput {
@@ -507,7 +506,6 @@ struct WasmBindgenOutput {
 }
 
 //////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////
 
 /// A wrapper around the cargo project's metadata.
 #[derive(Clone, Debug)]
@@ -521,7 +519,8 @@ pub struct CargoMetadata {
 }
 
 impl CargoMetadata {
-    /// Get the project's cargo metadata of the CWD, or of the project specified by the given manifest path.
+    /// Get the project's cargo metadata of the CWD, or of the project specified by the given
+    /// manifest path.
     pub async fn new(manifest: &Option<PathBuf>) -> Result<Self> {
         // Fetch the cargo project's metadata.
         let mut cmd = MetadataCommand::new();

--- a/src/config.rs
+++ b/src/config.rs
@@ -127,7 +127,6 @@ impl From<ConfigOptsClean> for RtcClean {
 }
 
 //////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////
 
 /// Config options for the build system.
 #[derive(Clone, Debug, Default, Deserialize, StructOpt)]
@@ -172,7 +171,8 @@ pub struct ConfigOptsServe {
     #[structopt(long = "proxy-backend")]
     #[serde(default)]
     pub proxy_backend: Option<Url>,
-    /// The URI on which to accept requests which are to be rewritten and proxied to backend [default: None]
+    /// The URI on which to accept requests which are to be rewritten and proxied to backend
+    /// [default: None]
     #[structopt(long = "proxy-rewrite")]
     #[serde(default)]
     pub proxy_rewrite: Option<String>,
@@ -193,7 +193,8 @@ pub struct ConfigOptsClean {
 /// Config options for building proxies.
 ///
 /// NOTE WELL: this configuration type is different from the others inasmuch as it is only used
-/// when parsing the `Trunk.toml` config file. It is not intended to be configured via CLI or env vars.
+/// when parsing the `Trunk.toml` config file. It is not intended to be configured via CLI or env
+/// vars.
 #[derive(Clone, Debug, Deserialize)]
 pub struct ConfigOptsProxy {
     /// The URL of the backend to which requests are to be proxied.


### PR DESCRIPTION
Closes: #51

The second commit is the result of running `cargo fmt` (which defaults to the nightly version on my system). I included it here because these changes will come to Rustfmt stable sooner or later anyway.
Happy to remove if you don't like it!

I implemented this as a new step rather than including it in an existing one because I feel like it didn't fit anywhere else.
The implementation itself is almost disappointingly unsophisticated.
If you have any concerns or comments, there's no need to hold back :)

I would also like to update the "documentation" to mention this feature but I'm unsure where to place it. This isn't really an "asset" but perhaps it could be added to the "images & other resources" section which already references the `--public-url` flag?