### PR TITLE
Fix thedodd/trunk#62

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This changelog follows the patterns described here: https://keepachangelog.com/e
 ### added
 - Support for writing the public URL (`--public-url`) to the HTML output. ([#59](https://github.com/thedodd/trunk/issues/55))
 
+### fixed
+
+- Closes [#62](https://github.com/thedodd/trunk/issues/62): Fixed an issue where the path of an asset file was mapped to an invalid path on Windows systems.
+
 ## 0.5.1
 ### fixed
 - Closes [#55](https://github.com/thedodd/trunk/issues/55): Fixed a regression in the server where the middleware was declared after the handler, and was thus not working as needed. Putting the middleware first fixes the issue.

--- a/src/build.rs
+++ b/src/build.rs
@@ -318,8 +318,11 @@ impl BuildSystem {
         // Update the DOM for each extracted asset as long as it is a valid FS path.
         let mut assets = vec![];
         for (idx, (mut node, href)) in asset_links {
-            // Take the path to referenced resource, if it is a valid asset, then we continue.
-            let path = self.target_html_dir.join(href.as_ref());
+            // href on Windos might be `dir/subdir` but using path join does not replace slash with backslash
+            // split href by path delimiter AND THEN use join causes the system to use the native path delimiter
+            let mut path = PathBuf::from(self.target_html_dir.as_path());
+            href.as_ref().split('/').for_each(|comp| path.push(comp));
+
             let rel = node.attr_or("rel", "").to_string().to_lowercase();
             let id = format!("link-{}", idx);
             let asset = match AssetFile::new(path, AssetType::Link { rel }, id, &self.progress).await {

--- a/src/build.rs
+++ b/src/build.rs
@@ -319,9 +319,9 @@ impl BuildSystem {
         let mut assets = vec![];
         for (idx, (mut node, href)) in asset_links {
             // href on Windos might be `dir/subdir` but using path join does not replace slash with backslash
-            // split href by path delimiter AND THEN use join causes the system to use the native path delimiter
+            // split href by path delimiter and then extend path with that
             let mut path = PathBuf::from(self.target_html_dir.as_path());
-            href.as_ref().split('/').for_each(|comp| path.push(comp));
+            path.extend(href.as_ref().split('/'));
 
             let rel = node.attr_or("rel", "").to_string().to_lowercase();
             let id = format!("link-{}", idx);


### PR DESCRIPTION
This fixes a resulting invalid path delimiter of asset files on Windows platforms by splitting the link first by a normal slash and then repeatedly joining over the path components.
This causes the join method to use the native path delimiter instead of a hardcoded one.