### PR TITLE
Ensure canonical path is taken when building ignore paths.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ changelog
 This changelog follows the patterns described here: https://keepachangelog.com/en/1.0.0/.
 
 ## Unreleased
+
+## 0.7.1
+### fixed
+- Closed [#76]((https://github.com/thedodd/trunk/issues/76): Ensure canonical paths are used for pertinent paths in the runtime config to ensure watch config is able to properly ignore the dist dir and such.
+
+## 0.7.0
 - Made a lot of refactoring progress to be able to support [#28](https://github.com/thedodd/trunk/issues/28) & [#46](https://github.com/thedodd/trunk/issues/46). More work remains to be done, but the foundation to be able to knock these items out is now in place.
 
 ### changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trunk"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2018"
 description = "Build, bundle & ship your Rust WASM application to the web."
 license = "MIT/Apache-2.0"

--- a/src/config/rt.rs
+++ b/src/config/rt.rs
@@ -22,15 +22,16 @@ pub struct RtcBuild {
 impl RtcBuild {
     /// Construct a new instance.
     pub(super) fn new(opts: ConfigOptsBuild) -> Result<Self> {
-        let target = opts.target.clone().unwrap_or_else(|| "index.html".into());
+        let pre_target = opts.target.clone().unwrap_or_else(|| "index.html".into());
+        let target = pre_target
+            .canonicalize()
+            .with_context(|| format!("error getting canonical path to source HTML file {:?}", &pre_target))?;
         let target_parent_dir = target
             .parent()
             .map(|path| path.to_owned())
             .unwrap_or_else(|| PathBuf::from(std::path::MAIN_SEPARATOR.to_string()));
         Ok(Self {
-            target: target
-                .canonicalize()
-                .with_context(|| format!("error getting canonical path to source HTML file {:?}", &target))?,
+            target,
             release: opts.release,
             dist: opts.dist.unwrap_or_else(|| target_parent_dir.join("dist")),
             public_url: opts.public_url.unwrap_or_else(|| "/".into()),


### PR DESCRIPTION
closes #76

**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [x] Updated README.md with pertinent info (may not always apply).
