### PR TITLE
Properly root all assets in the output index.html.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ This changelog follows the patterns described here: https://keepachangelog.com/e
 
 ## Unreleased
 
+## 0.7.2
+### fixed
+- Closed [#78](https://github.com/thedodd/trunk/issues/78): Ensure all asset pipelines are properly rooted to the configured `public-url`, which defaults to `/`.
+
 ## 0.7.1
 ### fixed
-- Closed [#76]((https://github.com/thedodd/trunk/issues/76): Ensure canonical paths are used for pertinent paths in the runtime config to ensure watch config is able to properly ignore the dist dir and such.
+- Closed [#76](https://github.com/thedodd/trunk/issues/76): Ensure canonical paths are used for pertinent paths in the runtime config to ensure watch config is able to properly ignore the dist dir and such.
 
 ## 0.7.0
 - Made a lot of refactoring progress to be able to support [#28](https://github.com/thedodd/trunk/issues/28) & [#46](https://github.com/thedodd/trunk/issues/46). More work remains to be done, but the foundation to be able to knock these items out is now in place.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,7 +2459,7 @@ dependencies = [
 
 [[package]]
 name = "trunk"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "async-process",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trunk"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2018"
 description = "Build, bundle & ship your Rust WASM application to the web."
 license = "MIT/Apache-2.0"

--- a/src/pipelines/icon.rs
+++ b/src/pipelines/icon.rs
@@ -45,6 +45,7 @@ impl Icon {
             let hashed_file_output = self.asset.copy_with_hash(&self.cfg.dist).await?;
             self.progress.set_message("finished copying & hashing icon");
             Ok(TrunkLinkPipelineOutput::Icon(IconOutput {
+                cfg: self.cfg.clone(),
                 id: self.id,
                 file: hashed_file_output,
             }))
@@ -54,6 +55,8 @@ impl Icon {
 
 /// The output of an Icon build pipeline.
 pub struct IconOutput {
+    /// The runtime build config.
+    pub cfg: Arc<RtcBuild>,
     /// The ID of this pipeline.
     pub id: usize,
     /// Data on the finalized output file.
@@ -62,8 +65,11 @@ pub struct IconOutput {
 
 impl IconOutput {
     pub async fn finalize(self, dom: &mut Document) -> Result<()> {
-        dom.select(&super::trunk_id_selector(self.id))
-            .replace_with_html(format!(r#"<link rel="icon" href="{}"/>"#, self.file.file_name));
+        dom.select(&super::trunk_id_selector(self.id)).replace_with_html(format!(
+            r#"<link rel="icon" href="{base}{file}"/>"#,
+            base = &self.cfg.public_url,
+            file = self.file.file_name
+        ));
         Ok(())
     }
 }

--- a/src/pipelines/rust_app.rs
+++ b/src/pipelines/rust_app.rs
@@ -236,9 +236,10 @@ impl RustApp {
 
 /// The output of a cargo build pipeline.
 pub struct RustAppOutput {
+    /// The runtime build config.
+    pub cfg: Arc<RtcBuild>,
     /// The ID of this pipeline.
     pub id: Option<usize>,
-    pub cfg: Arc<RtcBuild>,
     /// The filename of the generated JS loader file written to the dist dir.
     pub js_output: String,
     /// The filename of the generated WASM file written to the dist dir.


### PR DESCRIPTION
This ensures that all generated assets — CSS, SASS/SCSS, icons &c — are
all properly rooted to the configured `public-url`, which defaults to
`/`.

closes #78

**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [x] Updated README.md with pertinent info (may not always apply).
