### PR TITLE
Fix infinite watch loop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ changelog
 This changelog follows the patterns described here: https://keepachangelog.com/en/1.0.0/.
 
 ## Unreleased
+### fixed
+- Fixed infinite rebuild loop started by `watch` command by path canonicalizing in the ignored paths resolver.
 
 ## 0.7.3
 ### fixed

--- a/src/config/manifest.rs
+++ b/src/config/manifest.rs
@@ -20,7 +20,10 @@ impl CargoMetadata {
     pub async fn new(manifest: &Path) -> Result<Self> {
         let mut cmd = MetadataCommand::new();
         cmd.manifest_path(dunce::simplified(manifest));
-        let metadata = spawn_blocking(move || cmd.exec()).await?;
+
+        let mut metadata = spawn_blocking(move || cmd.exec()).await?;
+        metadata.target_directory = metadata.target_directory.canonicalize()?;
+
         let package = metadata
             .root_package()
             .cloned()

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -88,7 +88,7 @@ impl WatchSystem {
             DebouncedEvent::Create(path) | DebouncedEvent::Write(path) | DebouncedEvent::Remove(path) | DebouncedEvent::Rename(_, path) => path,
             _ => return,
         };
-      
+
         ev_path = match ev_path.canonicalize() {
             Ok(path) => path,
             Err(err) => return self.progress.println(format!("could not canonicalize path: {}", err)),
@@ -119,7 +119,10 @@ fn build_watcher(mut watch_tx: Sender<DebouncedEvent>, paths: Vec<PathBuf>) -> R
 
     for path in paths {
         watcher
-            .watch(path.clone(), RecursiveMode::Recursive)
+            .watch(
+                &path.clone().canonicalize().context(format!("failed to canonicalize path: {:?}", &path))?,
+                RecursiveMode::Recursive,
+            )
             .context(format!("failed to watch {:?} for file system changes", path))?;
     }
 


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).

**Problem:**
Infinite rebuild loop. 

![trunk_infinite_loop](https://user-images.githubusercontent.com/18517402/96332710-d9fe6000-1065-11eb-8e5a-155b75518cd3.gif)

**Cause:**
https://github.com/thedodd/trunk/blob/fdef076e05cad6b89e597b1ed2f33bce9b01c786/src/watch.rs#L87-L91

Paths `p` (_ignored path_) and `path` (_event path_) are often incorrectly evaluated as different, because some paths aren't canonicalized/normalized. As the result, events coming from ignored folders `dist` and `target` were handled and their content changed again by Trunk. Those changes caused firing new events and the cycle repeated.

Examples of such paths (`p` and `path` wrapped in `println!`):
```
...
____
IGNORED PATH: "C:\\work\\repos\\stremio-seed-poc\\target"
EVENT PATH: "C:\\work\\repos\\stremio-seed-poc\\.\\target"
____
IGNORED PATH: "\\\\?\\C:\\work\\repos\\stremio-seed-poc\\dist"
EVENT PATH: "C:\\work\\repos\\stremio-seed-poc\\.\\dist"
...

```
- Path with `target` is added through the _ignore channel_ during the build from manifest's metadata.
https://github.com/thedodd/trunk/blob/fdef076e05cad6b89e597b1ed2f33bce9b01c786/src/config/manifest.rs#L23

- Paths with dot (`\\.\\`) are created by watcher:
https://github.com/thedodd/trunk/blob/fdef076e05cad6b89e597b1ed2f33bce9b01c786/src/watch.rs#L108

**Solution**

Canonicalize/normalize all paths coming to the ignored path resolver.

I tried to canonicalize paths as soon as possible in this PR to prevent unnecessary extra `canonicalize` calls. However it's still possible, for instance, to pass "raw" paths through _ignore channel_ to reintroduce the similar issue.

So working with paths seems to be quite error-prone. I'm not sure there is an universal solution - e.g. introduce a custom `path` wrapper that would implicitly normalize all paths.