### PR TITLE
Watch include exclude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ changelog
 This changelog follows the patterns described here: https://keepachangelog.com/en/1.0.0/.
 
 ## Unreleased
+### added
+- Closed [#93](https://github.com/thedodd/trunk/issues/93): The `watch` and `serve` subcommands can now watch specific folder(s) or file(s) through the new `--watch <path>...` option.
 
 ## 0.7.4
 ### fixed

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -11,7 +11,9 @@ dist = "dist"
 public_url = "/"
 
 [watch]
-# Additional paths to ignore.
+# Paths to watch, defaults to build target parent folder.
+path = ["src"]
+# Paths to ignore.
 ignore = []
 
 [serve]

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -34,7 +34,8 @@ const ATTR_REL: &str = "rel";
 const SNIPPETS_DIR: &str = "snippets";
 const TRUNK_ID: &str = "data-trunk-id";
 
-/// A model of all of the supported Trunk asset links expressed in the source HTML as `<trunk-link/>` elements.
+/// A model of all of the supported Trunk asset links expressed in the source HTML as
+/// `<trunk-link/>` elements.
 ///
 /// Trunk will remove all `<trunk-link .../>` elements found in the HTML. It is the responsibility
 /// of each pipeline to implement a pipeline finalizer method for its pipeline output in order to
@@ -180,7 +181,8 @@ impl AssetFile {
         Ok(file_path)
     }
 
-    /// Copy this asset to the target dir after hashing its contents & updating the filename with the hash.
+    /// Copy this asset to the target dir after hashing its contents & updating the filename with
+    /// the hash.
     pub async fn copy_with_hash(&self, to_dir: &Path) -> Result<HashedFileOutput> {
         let bytes = fs::read(&self.path)
             .await

--- a/src/pipelines/rust_app.rs
+++ b/src/pipelines/rust_app.rs
@@ -27,9 +27,10 @@ pub struct RustApp {
     progress: ProgressBar,
     /// All metadata associated with the target Cargo project.
     manifest: CargoMetadata,
-    /// An optional channel to be used to communicate ignore paths to the watcher.
+    /// An optional channel to be used to communicate paths to ignore back to the watcher.
     ignore_chan: Option<Sender<PathBuf>>,
-    /// An optional binary name which will cause cargo & wasm-bindgen to process only the target binary.
+    /// An optional binary name which will cause cargo & wasm-bindgen to process only the target
+    /// binary.
     bin: Option<String>,
 }
 

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -18,7 +18,7 @@ pub struct WatchSystem {
     /// The build system.
     build: BuildSystem,
     /// The current vector of paths to be ignored.
-    ignores: Vec<PathBuf>,
+    ignored_paths: Vec<PathBuf>,
     /// A channel of FS watch events.
     watch_rx: Receiver<DebouncedEvent>,
     /// A channel of new paths to ignore from the build system.
@@ -35,22 +35,23 @@ impl WatchSystem {
         let (build_tx, build_rx) = channel(1);
 
         // Process ignore list.
-        let mut ignores = cfg.ignore.iter().try_fold(vec![], |mut acc, path| -> Result<Vec<PathBuf>> {
+        let mut ignored_paths = cfg.ignored_paths.iter().try_fold(vec![], |mut acc, path| -> Result<Vec<PathBuf>> {
             let abs_path = path.canonicalize().map_err(|err| anyhow!("invalid path provided: {}", err))?;
             acc.push(abs_path);
             Ok(acc)
         })?;
-        ignores.append(&mut vec![cfg.build.dist.clone()]);
+
+        ignored_paths.push(cfg.build.dist.clone());
 
         // Build the watcher.
-        let _watcher = build_watcher(watch_tx)?;
+        let _watcher = build_watcher(watch_tx, cfg.paths.clone())?;
 
         // Build dependencies.
         let build = BuildSystem::new(cfg.build.clone(), progress.clone(), Some(build_tx)).await?;
         Ok(Self {
             progress,
             build,
-            ignores,
+            ignored_paths,
             watch_rx,
             build_rx,
             _watcher,
@@ -84,33 +85,41 @@ impl WatchSystem {
             DebouncedEvent::Create(path) | DebouncedEvent::Write(path) | DebouncedEvent::Remove(path) | DebouncedEvent::Rename(_, path) => path,
             _ => return,
         };
-        for path in ev_path.ancestors() {
-            if self.ignores.iter().map(|p| p.as_path()).any(|p| p == path) {
-                return; // Don't emit a notification if ignored.
-            }
+
+        if ev_path
+            .ancestors()
+            .any(|path| self.ignored_paths.iter().any(|ignored_path| ignored_path == path))
+        {
+            return; // Don't emit a notification if path is ignored.
         }
+
         if let Err(err) = self.build.build().await {
             self.progress.println(format!("{}", err));
         }
     }
 
     fn update_ignore_list(&mut self, path: PathBuf) {
-        if !self.ignores.contains(&path) {
-            self.ignores.push(path);
+        if !self.ignored_paths.contains(&path) {
+            self.ignored_paths.push(path);
         }
     }
 }
 
-fn build_watcher(mut watch_tx: Sender<DebouncedEvent>) -> Result<(JoinHandle<()>, RecommendedWatcher)> {
+fn build_watcher(mut watch_tx: Sender<DebouncedEvent>, paths: Vec<PathBuf>) -> Result<(JoinHandle<()>, RecommendedWatcher)> {
     let (tx, rx) = std::sync::mpsc::channel();
     let mut watcher = watcher(tx, std::time::Duration::from_secs(1)).context("failed to build file system watcher")?;
-    watcher
-        .watch(".", RecursiveMode::Recursive)
-        .context("failed to watch CWD for file system changes")?;
+
+    for path in paths {
+        watcher
+            .watch(path.clone(), RecursiveMode::Recursive)
+            .context(format!("failed to watch {:?} for file system changes", path))?;
+    }
+
     let handle = spawn_blocking(move || loop {
         if let Ok(event) = rx.recv() {
             let _ = watch_tx.try_send(event);
         }
     });
+
     Ok((handle, watcher))
 }

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -35,11 +35,14 @@ impl WatchSystem {
         let (build_tx, build_rx) = channel(1);
 
         // Process ignore list.
-        let mut ignored_paths = cfg.ignored_paths.iter().try_fold(vec![], |mut acc, path| -> Result<Vec<PathBuf>> {
-            let abs_path = path.canonicalize().map_err(|err| anyhow!("invalid path provided: {}", err))?;
-            acc.push(abs_path);
-            Ok(acc)
-        })?;
+        let mut ignored_paths =
+            cfg.ignored_paths
+                .iter()
+                .try_fold(Vec::with_capacity(cfg.ignored_paths.len() + 1), |mut acc, path| -> Result<Vec<PathBuf>> {
+                    let abs_path = path.canonicalize().map_err(|err| anyhow!("invalid path provided: {}", err))?;
+                    acc.push(abs_path);
+                    Ok(acc)
+                })?;
 
         ignored_paths.push(cfg.build.dist.clone());
 


### PR DESCRIPTION
This adds the `--watch <path>...` option to the `serve` and `watch` subcommands which allows to watch specific folder(s) or file(s).

Closes #93 

**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [x] ~~Updated README.md with pertinent info (may not always apply).~~
