### PR TITLE
Add context to anyhow errors

### DIFF
--- a/src/pipelines/copydir.rs
+++ b/src/pipelines/copydir.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use async_std::fs;
 use async_std::task::{spawn, JoinHandle};
 use indicatif::ProgressBar;
@@ -33,7 +33,7 @@ impl CopyDir {
         // Build the path to the target asset.
         let href_attr = attrs
             .get(ATTR_HREF)
-            .ok_or_else(|| anyhow!(r#"required attr `href` missing for <link data-trunk rel="copydir" .../> element"#))?;
+            .context(r#"required attr `href` missing for <link data-trunk rel="copydir" .../> element"#)?;
         let mut path = PathBuf::new();
         path.extend(href_attr.split('/'));
         if !path.is_absolute() {
@@ -51,7 +51,7 @@ impl CopyDir {
                 .with_context(|| format!("error taking canonical path of directory {:?}", &self.path))?;
             let dir_name = canonical_path
                 .file_name()
-                .ok_or_else(|| anyhow!("could not get directory name of dir {:?}", &canonical_path))?;
+                .with_context(|| format!("could not get directory name of dir {:?}", &canonical_path))?;
             let dir_out = self.cfg.staging_dist.join(dir_name);
             copy_dir_recursive(canonical_path.into(), dir_out).await?;
             self.progress.set_message("finished copying directory");

--- a/src/pipelines/copyfile.rs
+++ b/src/pipelines/copyfile.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Context, Result};
 use async_std::task::{spawn, JoinHandle};
 use indicatif::ProgressBar;
 use nipper::Document;
@@ -31,7 +31,7 @@ impl CopyFile {
         // Build the path to the target asset.
         let href_attr = attrs
             .get(ATTR_HREF)
-            .ok_or_else(|| anyhow!(r#"required attr `href` missing for <link data-trunk rel="copyfile" .../> element"#))?;
+            .context(r#"required attr `href` missing for <link data-trunk rel="copyfile" .../> element"#)?;
         let mut path = PathBuf::new();
         path.extend(href_attr.split('/'));
         let asset = AssetFile::new(&html_dir, path).await?;

--- a/src/pipelines/css.rs
+++ b/src/pipelines/css.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Context, Result};
 use async_std::task::{spawn, JoinHandle};
 use indicatif::ProgressBar;
 use nipper::Document;
@@ -31,7 +31,7 @@ impl Css {
         // Build the path to the target asset.
         let href_attr = attrs
             .get(ATTR_HREF)
-            .ok_or_else(|| anyhow!(r#"required attr `href` missing for <link data-trunk rel="css" .../> element"#))?;
+            .context(r#"required attr `href` missing for <link data-trunk rel="css" .../> element"#)?;
         let mut path = PathBuf::new();
         path.extend(href_attr.split('/'));
         let asset = AssetFile::new(&html_dir, path).await?;

--- a/src/pipelines/html.rs
+++ b/src/pipelines/html.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use anyhow::{anyhow, ensure, Context, Result};
+use anyhow::{ensure, Context, Result};
 use async_std::fs;
 use async_std::task::{spawn_local, JoinHandle};
 use futures::channel::mpsc::Sender;
@@ -43,7 +43,7 @@ impl HtmlPipeline {
         let target_html_dir = Arc::new(
             target_html_path
                 .parent()
-                .ok_or_else(|| anyhow!("failed to determine parent dir of target HTML file"))?
+                .context("failed to determine parent dir of target HTML file")?
                 .to_owned(),
         );
 

--- a/src/pipelines/icon.rs
+++ b/src/pipelines/icon.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Context, Result};
 use async_std::task::{spawn, JoinHandle};
 use indicatif::ProgressBar;
 use nipper::Document;
@@ -31,7 +31,7 @@ impl Icon {
         // Build the path to the target asset.
         let href_attr = attrs
             .get(ATTR_HREF)
-            .ok_or_else(|| anyhow!(r#"required attr `href` missing for <link data-trunk rel="icon" .../> element"#))?;
+            .context(r#"required attr `href` missing for <link data-trunk rel="icon" .../> element"#)?;
         let mut path = PathBuf::new();
         path.extend(href_attr.split('/'));
         let asset = AssetFile::new(&html_dir, path).await?;

--- a/src/pipelines/inline.rs
+++ b/src/pipelines/inline.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Context, Result};
 use async_std::task::{spawn, JoinHandle};
 use indicatif::ProgressBar;
 use nipper::Document;
@@ -30,7 +30,7 @@ impl Inline {
     pub async fn new(progress: ProgressBar, html_dir: Arc<PathBuf>, attrs: LinkAttrs, id: usize) -> Result<Self> {
         let href_attr = attrs
             .get(ATTR_HREF)
-            .ok_or_else(|| anyhow!(r#"required attr `href` missing for <link data-trunk rel="inline" .../> element"#))?;
+            .context(r#"required attr `href` missing for <link data-trunk rel="inline" .../> element"#)?;
 
         let mut path = PathBuf::new();
         path.extend(href_attr.split('/'));

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -13,7 +13,7 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use anyhow::{anyhow, bail, ensure, Context, Result};
+use anyhow::{bail, ensure, Context, Result};
 use async_std::fs;
 use async_std::task::JoinHandle;
 use futures::channel::mpsc::Sender;
@@ -66,7 +66,7 @@ impl TrunkLink {
     ) -> Result<Self> {
         let rel = attrs
             .get(ATTR_REL)
-            .ok_or_else(|| anyhow!("all <link data-trunk .../> elements must have a `rel` attribute indicating the asset type"))?;
+            .context("all <link data-trunk .../> elements must have a `rel` attribute indicating the asset type")?;
         Ok(match rel.as_str() {
             Sass::TYPE_SASS | Sass::TYPE_SCSS => Self::Sass(Sass::new(cfg, progress, html_dir, attrs, id).await?),
             Icon::TYPE_ICON => Self::Icon(Icon::new(cfg, progress, html_dir, attrs, id).await?),

--- a/src/pipelines/rust_app.rs
+++ b/src/pipelines/rust_app.rs
@@ -230,14 +230,14 @@ impl RustApp {
                 cargo_metadata::Message::BuildFinished(finished) if !finished.success => Err(anyhow!("error while fetching cargo artifact info")),
                 _ => acc,
             })?
-            .ok_or_else(|| anyhow!("cargo artifacts not found for target crate"))?;
+            .context("cargo artifacts not found for target crate")?;
 
         // Get a handle to the WASM output file.
         let wasm = artifact
             .filenames
             .into_iter()
             .find(|path| path.extension().map(|ext| ext == "wasm").unwrap_or(false))
-            .ok_or_else(|| anyhow!("could not find WASM output after cargo build"))?;
+            .context("could not find WASM output after cargo build")?;
 
         // Hash the built wasm app, then use that as the out-name param.
         self.progress.set_message("processing WASM");

--- a/src/pipelines/sass.rs
+++ b/src/pipelines/sass.rs
@@ -33,7 +33,7 @@ impl Sass {
         // Build the path to the target asset.
         let href_attr = attrs
             .get(ATTR_HREF)
-            .ok_or_else(|| anyhow!(r#"required attr `href` missing for <link data-trunk rel="sass|scss" .../> element"#))?;
+            .context(r#"required attr `href` missing for <link data-trunk rel="sass|scss" .../> element"#)?;
         let mut path = PathBuf::new();
         path.extend(href_attr.split('/'));
         let asset = AssetFile::new(&html_dir, path).await?;


### PR DESCRIPTION
This just removes a few raw usages of `anyhow!` and replaces them with errors that add context, with the goal of improving error message usefulness.
