### PR TITLE
Fix clippy warnings and CI errors for clippy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,9 +33,9 @@ jobs:
           components: clippy, rustfmt
 
       - name: Build | Clippy
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/clippy-check@v1
         with:
-          command: clippy
+          token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-targets -- -D warnings
 
       - name: Build | Rustfmt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,9 +33,9 @@ jobs:
           components: clippy, rustfmt
 
       - name: Build | Clippy
-        uses: actions-rs/clippy-check@v1
+        uses: actions-rs/cargo@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          command: clippy
           args: --all-targets -- -D warnings
 
       - name: Build | Rustfmt

--- a/src/pipelines/inline.rs
+++ b/src/pipelines/inline.rs
@@ -64,9 +64,9 @@ pub enum ContentType {
     /// Html is just pasted into `index.html` as is.
     Html,
     /// CSS is wrapped into `style` tags.
-    CSS,
+    Css,
     /// JS is wrapped into `script` tags.
-    JS,
+    Js,
 }
 
 impl ContentType {
@@ -86,8 +86,8 @@ impl FromStr for ContentType {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "html" => Ok(Self::Html),
-            "css" => Ok(Self::CSS),
-            "js" => Ok(Self::JS),
+            "css" => Ok(Self::Css),
+            "js" => Ok(Self::Js),
             s => bail!(
                 r#"unknown `type="{}"` value for <link data-trunk rel="inline" .../> attr; please ensure the value is lowercase and is a supported content type"#,
                 s
@@ -110,8 +110,8 @@ impl InlineOutput {
     pub async fn finalize(self, dom: &mut Document) -> Result<()> {
         let html = match self.content_type {
             ContentType::Html => self.content,
-            ContentType::CSS => format!("<style>{}</style>", self.content),
-            ContentType::JS => format!("<script>{}</script>", self.content),
+            ContentType::Css => format!("<style>{}</style>", self.content),
+            ContentType::Js => format!("<script>{}</script>", self.content),
         };
 
         dom.select(&super::trunk_id_selector(self.id)).replace_with_html(html);


### PR DESCRIPTION
Fix the current clippy lint and CI errors by:
- ~~Adjusting the CI job to use the cargo action and execute clippy directly instead of using the clippy-check action. This error happens as PRs are not able to add annotations to to the code.~~
- Fixing the naming errors that are reported by the latest clippy from just released Rust 1.51.
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [x] Updated README.md with pertinent info (may not always apply).
