### PR TITLE
Switch to using relative-path for link paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This changelog follows the patterns described here: https://keepachangelog.com/e
 Subheadings to categorize changes are `added, changed, deprecated, removed, fixed, security`.
 
 ## Unreleased
+### changed
+- Correctly treat `<link href>` attributes as relative path in a platform neutral manner.
 
 ## 0.11.0
 ### added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2065,6 +2065,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
 
 [[package]]
+name = "relative-path"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a479d53d7eed831f3c92ca79c61002d5987e21417d528296832f802bca532380"
+
+[[package]]
 name = "remove_dir_all"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2867,6 +2873,7 @@ dependencies = [
  "nipper-trunk",
  "notify",
  "open",
+ "relative-path",
  "remove_dir_all",
  "sass-rs",
  "seahash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ tide-websockets = "0.3.0"
 toml = "0.5"
 tracing = "0.1.25"
 tracing-subscriber = "0.2.16"
+relative-path = "1.4.0"
 
 [dev-dependencies]
 insta = "0.16.1"

--- a/src/pipelines/copy_dir.rs
+++ b/src/pipelines/copy_dir.rs
@@ -7,6 +7,7 @@ use anyhow::{Context, Result};
 use async_std::fs;
 use async_std::task::{spawn, JoinHandle};
 use nipper::Document;
+use relative_path::RelativePath;
 
 use super::ATTR_HREF;
 use super::{LinkAttrs, TrunkLinkPipelineOutput};
@@ -30,12 +31,9 @@ impl CopyDir {
         // Build the path to the target asset.
         let href_attr = attrs
             .get(ATTR_HREF)
+            .map(RelativePath::new)
             .context(r#"required attr `href` missing for <link data-trunk rel="copydir" .../> element"#)?;
-        let mut path = PathBuf::new();
-        path.extend(href_attr.split('/'));
-        if !path.is_absolute() {
-            path = html_dir.join(path);
-        }
+        let path = href_attr.to_logical_path(&*html_dir);
         Ok(Self { id, cfg, path })
     }
 

--- a/src/pipelines/copy_file.rs
+++ b/src/pipelines/copy_file.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use async_std::task::{spawn, JoinHandle};
 use nipper::Document;
+use relative_path::RelativePath;
 
 use super::ATTR_HREF;
 use super::{AssetFile, LinkAttrs, TrunkLinkPipelineOutput};
@@ -28,10 +29,10 @@ impl CopyFile {
         // Build the path to the target asset.
         let href_attr = attrs
             .get(ATTR_HREF)
+            .map(RelativePath::new)
             .context(r#"required attr `href` missing for <link data-trunk rel="copyfile" .../> element"#)?;
-        let mut path = PathBuf::new();
-        path.extend(href_attr.split('/'));
-        let asset = AssetFile::new(&html_dir, path).await?;
+        let path = href_attr.to_logical_path(&*html_dir);
+        let asset = AssetFile::new(&path).await?;
         Ok(Self { id, cfg, asset })
     }
 

--- a/src/pipelines/css.rs
+++ b/src/pipelines/css.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use async_std::task::{spawn, JoinHandle};
 use nipper::Document;
+use relative_path::RelativePath;
 
 use super::ATTR_HREF;
 use super::{AssetFile, HashedFileOutput, LinkAttrs, TrunkLinkPipelineOutput};
@@ -28,10 +29,10 @@ impl Css {
         // Build the path to the target asset.
         let href_attr = attrs
             .get(ATTR_HREF)
+            .map(RelativePath::new)
             .context(r#"required attr `href` missing for <link data-trunk rel="css" .../> element"#)?;
-        let mut path = PathBuf::new();
-        path.extend(href_attr.split('/'));
-        let asset = AssetFile::new(&html_dir, path).await?;
+        let path = href_attr.to_logical_path(&*html_dir);
+        let asset = AssetFile::new(&path).await?;
         Ok(Self { id, cfg, asset })
     }
 

--- a/src/pipelines/icon.rs
+++ b/src/pipelines/icon.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use async_std::task::{spawn, JoinHandle};
 use nipper::Document;
+use relative_path::RelativePath;
 
 use super::ATTR_HREF;
 use super::{AssetFile, HashedFileOutput, LinkAttrs, TrunkLinkPipelineOutput};
@@ -28,10 +29,10 @@ impl Icon {
         // Build the path to the target asset.
         let href_attr = attrs
             .get(ATTR_HREF)
+            .map(RelativePath::new)
             .context(r#"required attr `href` missing for <link data-trunk rel="icon" .../> element"#)?;
-        let mut path = PathBuf::new();
-        path.extend(href_attr.split('/'));
-        let asset = AssetFile::new(&html_dir, path).await?;
+        let path = href_attr.to_logical_path(&*html_dir);
+        let asset = AssetFile::new(&path).await?;
         Ok(Self { id, cfg, asset })
     }
 

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -148,17 +148,12 @@ impl AssetFile {
     ///
     /// Any errors returned from this constructor indicate that one of these invariants was not
     /// upheld.
-    pub async fn new(rel_dir: &Path, mut path: PathBuf) -> Result<Self> {
-        // If the given path is not absolute, then we join it with the directory from which the
-        // relative path should be based.
-        if !path.is_absolute() {
-            path = rel_dir.join(path);
-        }
-
+    pub async fn new(path: &Path) -> Result<Self> {
         // Take the path to referenced resource, if it is actually an FS path, then we continue.
-        let path = fs::canonicalize(&path)
+        let path = fs::canonicalize(path)
             .await
-            .with_context(|| format!("error getting canonical path for {:?}", &path))?;
+            .with_context(|| format!("error getting canonical path for {}", path.display()))?;
+
         ensure!(path.is_file().await, "target file does not appear to exist on disk {:?}", &path);
         let file_name = match path.file_name() {
             Some(file_name) => file_name.to_owned(),


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [*] Updated CHANGELOG.md describing pertinent changes.
- [*] Updated README.md with pertinent info (may not always apply).
- [*] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will `:)`.

So this switches `href` parsing to go through `RelativePath` and `to_logical_path`.

There are two benefits to this:

#### Some relative paths are broken on Windows

`RelativePath::to_logical_path` treats the path using the non-platform path separator `/` and applies the logical operations that the relative path corresponds to, allowing relative paths to work on Windows. Otherwise the concatenated path in some instances ends up looking like this:

```rust
let html_dir = fs::canonicalize("dir"); // -> gives something like `\\?\C:\path\dir`
let path = html_dir.join(".."); // -> `\\?\C:\path\dir\..`
```

The short version is that the escape sequence causes `..` to be treated as a file - not the parent directory as expected.
See [msdn](https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file?redirectedfrom=MSDN#win32-file-namespaces) for more.

We instead avoid this by parsing relative paths using `relative-path` instead:

```rust
let html_dir = fs::canonicalize("dir"); // -> gives something like `\\?\C:\path\dir`
let path = RelativePath::new("..").to_logical_path(&html_dir); // -> `\\?\C:\path` which is what we want!
```

See: https://github.com/udoprog/patterns/blob/main/examples/relative-path.rs

#### Path separator in `relative-path` is platform neutral

This isn't much of a real world issue, but `relative-path` will only ever parse separated path components with a forward slash `/` which guarantees some degree of equal treatment regardless of platform, similar to how you currently use `split('/')` and `extend`.