### PR TITLE
Require opt-in to enable optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This changelog follows the patterns described here: https://keepachangelog.com/e
 Subheadings to categorize changes are `added, changed, deprecated, removed, fixed, security`.
 
 ## Unreleased
+### changed
+- Optimizations like `wasm-opt` must be opted in by passing `--optimize` or setting the `optimize` option in build settings.
 
 ## 0.11.0
 ### added

--- a/README.md
+++ b/README.md
@@ -121,7 +121,12 @@ Currently supported asset types:
   - `href`: (optional) the path to the `Cargo.toml` of the Rust project. If a directory is specified, then Trunk will look for the `Cargo.toml` in the given directory. If no value is specified, then Trunk will look for a `Cargo.toml` in the parent directory of the source HTML file.
   - `data-bin`: (optional) the name of the binary to compile and use as the main WASM application. If the Cargo project has multiple binaries, this value will be required for proper functionality.
   - `data-cargo-features`: (optional) Space or comma separated list of cargo features to activate.
-  - `data-wasm-opt`: (optional) run wasm-opt with the set optimization level. wasm-opt is **turned off by default** but that may change in the future. The possible values are `0`, `1`, `2`, `3`, `4`, `s`, `z` or an _empty value_ for wasm-opt's default. Set this option to `0` to disable wasm-opt explicitly. The values `1-4` are increasingly stronger optimization levels for speed. `s` and `z` (z means more optimization) optimize for binary size instead.
+  - `data-wasm-opt`: (optional) run wasm-opt with the set optimization level.
+    wasm-opt is **turned off by default** and even when this attribute is present will only run if enabled through `--optimize`.
+    The possible values are `0`, `1`, `2`, `3`, `4`, `s`, `z` or an _empty value_ for wasm-opt's default.
+    Set this option to `0` to disable wasm-opt explicitly.
+    The values `1-4` are increasingly stronger optimization levels for speed.
+    `s` and `z` (z means more optimization) optimize for binary size instead.
   - `data-keep-debug`: (optional) instruct `wasm-bindgen` to preserve debug info in the final WASM output, even for `--release` mode.
   - `data-no-demangle`: (optional) instruct `wasm-bindgen` to not demangle Rust symbol names.
 - ✅ `sass`, `scss`: Trunk ships with a [built-in sass/scss compiler](https://github.com/compass-rs/sass-rs). Just link to your sass files from your source HTML, and Trunk will handle the rest. This content is hashed for cache control. The `href` attribute must be included in the link pointing to the sass/scss file to be processed.

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -15,7 +15,7 @@ pub struct ConfigOptsBuild {
     /// The index HTML file to drive the bundling process [default: index.html]
     #[structopt(parse(from_os_str))]
     pub target: Option<PathBuf>,
-    /// Build in release mode [default: false]
+    /// Build in release mode [default: false].
     #[structopt(long)]
     #[serde(default)]
     pub release: bool,
@@ -25,6 +25,13 @@ pub struct ConfigOptsBuild {
     /// The public URL from which assets are to be served [default: /]
     #[structopt(long, parse(from_str=parse_public_url))]
     pub public_url: Option<String>,
+    /// Whether or not optimizations are enabled [default: false].
+    ///
+    /// This is required for options like `data-wasm-opt` to take effect,
+    /// because it can otherwise be very slow.
+    #[structopt(long)]
+    #[serde(default)]
+    pub optimize: bool,
 }
 
 /// Config options for the watch system.
@@ -157,6 +164,7 @@ impl ConfigOpts {
             release: cli.release,
             dist: cli.dist,
             public_url: cli.public_url,
+            optimize: cli.optimize,
         };
         let cfg_build = ConfigOpts {
             build: Some(opts),

--- a/src/config/rt.rs
+++ b/src/config/rt.rs
@@ -21,6 +21,8 @@ pub struct RtcBuild {
     pub final_dist: PathBuf,
     /// The directory used to stage build artifacts during an active build.
     pub staging_dist: PathBuf,
+    /// Whether or not optimizations are enabled.
+    pub optimize: bool,
 }
 
 impl RtcBuild {
@@ -56,6 +58,7 @@ impl RtcBuild {
             staging_dist,
             final_dist,
             public_url: opts.public_url.unwrap_or_else(|| "/".into()),
+            optimize: opts.optimize,
         })
     }
 }

--- a/src/pipelines/rust_app.rs
+++ b/src/pipelines/rust_app.rs
@@ -253,6 +253,11 @@ impl RustApp {
             return Ok(());
         }
 
+        if !self.cfg.optimize {
+            tracing::warn!("skipping wasm-opt since optimizations are not explicitly enabled with `--optimize`");
+            return Ok(());
+        }
+
         // Ensure our output dir is in place.
         tracing::info!("calling wasm-opt");
         let mode_segment = if self.cfg.release { "release" } else { "debug" };


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [*] Updated CHANGELOG.md describing pertinent changes.
- [*] Updated README.md with pertinent info (may not always apply).
- [*] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will `:)`.

This requires the user to explicitly enable optimizations through `--optimize` or by using the `optimize` option in `Trunk.toml` for potentially expensive optimizations to run.

This option is sorely needed, because optimizations might be enabled through static configuration in a `<link data-wasm-opt="z">` statement in `index.html`, but you don't necessarily want that to run while working locally. So without another toggle you constantly have to edit your `index.html` file instead.

This is also a breaking change.

It might also be desirable to implicitly enable optimizations if `--release` is specified, but in that case I'd like to have a `--no-optimize` option as well, because I sometimes want to enable release builds while developing locally without optimizing as well. I'd prefer to add this separate to this PR though, because I haven't fully wrapped my head around the `config` module yet and how to best make multiple options interoperate.