### PR TITLE
Add RSS feed to blog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 ### added
 - Closed [#139](https://github.com/thedodd/trunk/issues/139): Download and manage external applications (namely `wasm-bindgen` and `wasm-opt`) automatically. If available in the right version, system installed binaries are used but if absent the right version is downloaded and installed. This allows to use trunk without the extra steps of downloading the needed binaries manually.
 - Added an example application for using Trunk with a vanilla (no frameworks) Rust application.
-- Closed [#168](https://github.com/thedodd/trunk/issues/158): RSS feed for blog
 
 ### changed
 - `wasm-opt` is now enabled by default (with default optimization level) as the binary is automatically downloaded and installed by trunk. It can still be disabled by setting `data-wasm-opt` to `0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This changelog follows the patterns described here: https://keepachangelog.com/e
 Subheadings to categorize changes are `added, changed, deprecated, removed, fixed, security`.
 
 ## Unreleased
+### added
+- Closed [#168](https://github.com/thedodd/trunk/issues/158): RSS feed for blog
 
 ## 0.12.1
 ### fixed
@@ -14,6 +16,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 ### added
 - Closed [#139](https://github.com/thedodd/trunk/issues/139): Download and manage external applications (namely `wasm-bindgen` and `wasm-opt`) automatically. If available in the right version, system installed binaries are used but if absent the right version is downloaded and installed. This allows to use trunk without the extra steps of downloading the needed binaries manually.
 - Added an example application for using Trunk with a vanilla (no frameworks) Rust application.
+- Closed [#168](https://github.com/thedodd/trunk/issues/158): RSS feed for blog
 
 ### changed
 - `wasm-opt` is now enabled by default (with default optimization level) as the binary is automatically downloaded and installed by trunk. It can still be disabled by setting `data-wasm-opt` to `0`.

--- a/site/config.toml
+++ b/site/config.toml
@@ -6,6 +6,7 @@ compile_sass = true
 highlight_code = true
 highlight_theme = "inspired-github"
 build_search_index = true
+generate_feed = true
 
 theme = "juice"
 

--- a/site/templates/blog.html
+++ b/site/templates/blog.html
@@ -3,6 +3,12 @@
 
 {% block title %}{{ section.title }} | {{ super() }} {% endblock title %}
 
+{% block head %}
+{% block rss %}
+  <link rel="alternate" type="application/atom+xml" title="RSS" href="{{ get_url(path="atom.xml", trailing_slash=false) }}">
+{% endblock %}
+{% endblock head %}
+
 {% block header %}
 <header class="box-shadow">
     {{ macros::render_header() }}
@@ -11,6 +17,7 @@
 
 {% block toc %}
 <div class="toc">
+    <h2 class="toc-item"><a href="/atom.xml">Subscribe</a></h2>
     <div class="toc-sticky">
         {% for post in section.pages %}
         <div class="toc-item">


### PR DESCRIPTION
**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [x] ~Updated README.md with pertinent info (may not always apply).~
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will `:)`.

👋🏻 I've really enjoyed using Trunk so I thought I'd give back a little. I noticed the [RSS feed issue](https://github.com/thedodd/trunk/issues/168) and thought I'd knock that out real quick.

I don't know the `juice` theme very well so I did my best regarding styling, but if you have a particular location or look and feel in mind, please let me know!

For now, I put the subscribe link above the table of contents. It is outside the sticky group so it will scroll away as a user reads the list of posts. You can see a screenshot at the bottom of this PR.

I considered putting a link in the footer and on an individual blog post as well, but neither of them felt quite right. I can keep working on a good solution for that, but I wanted to open the PR first in case you're good with a single link on the blog landing page.

# Additions
- Zola RSS feed (which will be at https://trunkrs.dev/atom.xml)
- Subscribe link above the table of contents on the main blog page
- Post auto-discovery

## Screenshot
![image](https://user-images.githubusercontent.com/3434045/118757810-ab767c80-b822-11eb-9c5a-6d9e04a631ca.png)