### PR TITLE
Extending rel=icon, adding rel=manifest and PWA properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This changelog follows the patterns described here: https://keepachangelog.com/e
 Subheadings to categorize changes are `added, changed, deprecated, removed, fixed, security`.
 
 ## Unreleased
+- Changed properies of `rel=icon` link handling, they are extended with optional `sizes`, `type` attributes
+- Added pipeline for web application manifest reference aka `rel=manifest` link
+- Added pipelines for `rel=apple-touch-icon`, `rel=apple-touch-icon-precomposed`, `rel=apple-touch-startup-image` asset generation
 - Added an example application for using Trunk with a vanilla (no frameworks) Rust application.
 
 ## 0.11.0

--- a/src/pipelines/apple_touch_icon.rs
+++ b/src/pipelines/apple_touch_icon.rs
@@ -1,4 +1,4 @@
-//! Icon asset pipeline.
+//! AppleTouchIcon asset pipeline.
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -11,34 +11,31 @@ use super::ATTR_HREF;
 use super::{AssetFile, HashedFileOutput, LinkAttrs, TrunkLinkPipelineOutput};
 use crate::config::RtcBuild;
 
-/// An Icon asset pipeline.
-pub struct Icon {
+/// An AppleTouchIcon asset pipeline.
+pub struct AppleTouchIcon {
     /// The ID of this pipeline's source HTML element.
     id: usize,
     /// Runtime build config.
     cfg: Arc<RtcBuild>,
     /// The asset file being processed.
     asset: AssetFile,
-    /// Optional type attribute (like type="image/x-icon")
-    icon_type: Option<String>,
     /// Optional sizes attribute
     sizes: Option<String>,
 }
 
-impl Icon {
-    pub const TYPE_ICON: &'static str = "icon";
+impl AppleTouchIcon {
+    pub const TYPE_APPLE_TOUCH_ICON: &'static str = "apple-touch-icon";
 
     pub async fn new(cfg: Arc<RtcBuild>, html_dir: Arc<PathBuf>, attrs: LinkAttrs, id: usize) -> Result<Self> {
         // Build the path to the target asset.
         let href_attr = attrs
             .get(ATTR_HREF)
-            .context(r#"required attr `href` missing for <link data-trunk rel="icon" .../> element"#)?;
+            .context(r#"required attr `href` missing for <link data-trunk rel="apple-touch-icon" .../> element"#)?;
         let mut path = PathBuf::new();
         path.extend(href_attr.split('/'));
         let asset = AssetFile::new(&html_dir, path).await?;
-        let icon_type = attrs.get("type").map(|x| x.to_owned());
         let sizes = attrs.get("sizes").map(|x| x.to_owned());
-        Ok(Self { id, cfg, asset, icon_type, sizes })
+        Ok(Self { id, cfg, asset, sizes })
     }
 
     /// Spawn the pipeline for this asset type.
@@ -51,44 +48,38 @@ impl Icon {
     #[tracing::instrument(level = "trace", skip(self))]
     async fn run(self) -> Result<TrunkLinkPipelineOutput> {
         let rel_path = crate::common::strip_prefix(&self.asset.path);
-        tracing::info!(path = ?rel_path, "copying & hashing icon");
+        tracing::info!(path = ?rel_path, "copying & hashing apple-touch-icon");
         let hashed_file_output = self.asset.copy_with_hash(&self.cfg.staging_dist).await?;
-        tracing::info!(path = ?rel_path, "finished copying & hashing icon");
-        Ok(TrunkLinkPipelineOutput::Icon(IconOutput {
+        tracing::info!(path = ?rel_path, "finished copying & hashing apple-touch-icon");
+        Ok(TrunkLinkPipelineOutput::AppleTouchIcon(AppleTouchIconOutput {
             cfg: self.cfg.clone(),
             id: self.id,
             file: hashed_file_output,
-            icon_type: self.icon_type,
             sizes: self.sizes,
         }))
     }
 }
 
-/// The output of an Icon build pipeline.
-pub struct IconOutput {
+/// The output of an AppleTouchIcon build pipeline.
+pub struct AppleTouchIconOutput {
     /// The runtime build config.
     pub cfg: Arc<RtcBuild>,
     /// The ID of this pipeline.
     pub id: usize,
     /// Data on the finalized output file.
     pub file: HashedFileOutput,
-    /// Optional type attribute (like type="image/x-icon")
-    pub icon_type: Option<String>,
     /// Optional sizes attribute
     pub sizes: Option<String>,
 }
 
-impl IconOutput {
+impl AppleTouchIconOutput {
     pub async fn finalize(self, dom: &mut Document) -> Result<()> {
         let mut opts: Vec<String> = vec![];
-        if let Some(icon_type) = self.icon_type {
-            opts.push(format!("type=\"{}\"", icon_type));
-        }
         if let Some(sizes) = self.sizes {
             opts.push(format!("sizes=\"{}\"", sizes));
         }
         dom.select(&super::trunk_id_selector(self.id)).replace_with_html(format!(
-            r#"<link rel="icon" href="{base}{file}" {optional}/>"#,
+            r#"<link rel="apple-touch-icon" href="{base}{file}" {optional}/>"#,
             base = &self.cfg.public_url,
             file = self.file.file_name,
             optional = opts.join(" "),

--- a/src/pipelines/apple_touch_icon_precomposed.rs
+++ b/src/pipelines/apple_touch_icon_precomposed.rs
@@ -1,4 +1,4 @@
-//! Icon asset pipeline.
+//! AppleTouchIconPrecomposed asset pipeline.
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -11,34 +11,31 @@ use super::ATTR_HREF;
 use super::{AssetFile, HashedFileOutput, LinkAttrs, TrunkLinkPipelineOutput};
 use crate::config::RtcBuild;
 
-/// An Icon asset pipeline.
-pub struct Icon {
+/// An AppleTouchIconPrecomposed asset pipeline.
+pub struct AppleTouchIconPrecomposed {
     /// The ID of this pipeline's source HTML element.
     id: usize,
     /// Runtime build config.
     cfg: Arc<RtcBuild>,
     /// The asset file being processed.
     asset: AssetFile,
-    /// Optional type attribute (like type="image/x-icon")
-    icon_type: Option<String>,
     /// Optional sizes attribute
     sizes: Option<String>,
 }
 
-impl Icon {
-    pub const TYPE_ICON: &'static str = "icon";
+impl AppleTouchIconPrecomposed {
+    pub const TYPE_APPLE_TOUCH_ICON_PRECOMPOSED: &'static str = "apple-touch-icon-precomposed";
 
     pub async fn new(cfg: Arc<RtcBuild>, html_dir: Arc<PathBuf>, attrs: LinkAttrs, id: usize) -> Result<Self> {
         // Build the path to the target asset.
         let href_attr = attrs
             .get(ATTR_HREF)
-            .context(r#"required attr `href` missing for <link data-trunk rel="icon" .../> element"#)?;
+            .context(r#"required attr `href` missing for <link data-trunk rel="apple-touch-icon-precomposed" .../> element"#)?;
         let mut path = PathBuf::new();
         path.extend(href_attr.split('/'));
         let asset = AssetFile::new(&html_dir, path).await?;
-        let icon_type = attrs.get("type").map(|x| x.to_owned());
         let sizes = attrs.get("sizes").map(|x| x.to_owned());
-        Ok(Self { id, cfg, asset, icon_type, sizes })
+        Ok(Self { id, cfg, asset, sizes })
     }
 
     /// Spawn the pipeline for this asset type.
@@ -51,44 +48,38 @@ impl Icon {
     #[tracing::instrument(level = "trace", skip(self))]
     async fn run(self) -> Result<TrunkLinkPipelineOutput> {
         let rel_path = crate::common::strip_prefix(&self.asset.path);
-        tracing::info!(path = ?rel_path, "copying & hashing icon");
+        tracing::info!(path = ?rel_path, "copying & hashing apple-touch-icon-precomposed");
         let hashed_file_output = self.asset.copy_with_hash(&self.cfg.staging_dist).await?;
-        tracing::info!(path = ?rel_path, "finished copying & hashing icon");
-        Ok(TrunkLinkPipelineOutput::Icon(IconOutput {
+        tracing::info!(path = ?rel_path, "finished copying & hashing apple-touch-icon-precomposed");
+        Ok(TrunkLinkPipelineOutput::AppleTouchIconPrecomposed(AppleTouchIconPrecomposedOutput {
             cfg: self.cfg.clone(),
             id: self.id,
             file: hashed_file_output,
-            icon_type: self.icon_type,
             sizes: self.sizes,
         }))
     }
 }
 
-/// The output of an Icon build pipeline.
-pub struct IconOutput {
+/// The output of an AppleTouchIconPrecomposed build pipeline.
+pub struct AppleTouchIconPrecomposedOutput {
     /// The runtime build config.
     pub cfg: Arc<RtcBuild>,
     /// The ID of this pipeline.
     pub id: usize,
     /// Data on the finalized output file.
     pub file: HashedFileOutput,
-    /// Optional type attribute (like type="image/x-icon")
-    pub icon_type: Option<String>,
     /// Optional sizes attribute
     pub sizes: Option<String>,
 }
 
-impl IconOutput {
+impl AppleTouchIconPrecomposedOutput {
     pub async fn finalize(self, dom: &mut Document) -> Result<()> {
         let mut opts: Vec<String> = vec![];
-        if let Some(icon_type) = self.icon_type {
-            opts.push(format!("type=\"{}\"", icon_type));
-        }
         if let Some(sizes) = self.sizes {
             opts.push(format!("sizes=\"{}\"", sizes));
         }
         dom.select(&super::trunk_id_selector(self.id)).replace_with_html(format!(
-            r#"<link rel="icon" href="{base}{file}" {optional}/>"#,
+            r#"<link rel="apple-touch-icon-precomposed" href="{base}{file}" {optional}/>"#,
             base = &self.cfg.public_url,
             file = self.file.file_name,
             optional = opts.join(" "),

--- a/src/pipelines/apple_touch_startup_image.rs
+++ b/src/pipelines/apple_touch_startup_image.rs
@@ -1,4 +1,4 @@
-//! Icon asset pipeline.
+//! AppleTouchStartupImage asset pipeline.
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -11,34 +11,31 @@ use super::ATTR_HREF;
 use super::{AssetFile, HashedFileOutput, LinkAttrs, TrunkLinkPipelineOutput};
 use crate::config::RtcBuild;
 
-/// An Icon asset pipeline.
-pub struct Icon {
+/// An AppleTouchStartupImage asset pipeline.
+pub struct AppleTouchStartupImage {
     /// The ID of this pipeline's source HTML element.
     id: usize,
     /// Runtime build config.
     cfg: Arc<RtcBuild>,
     /// The asset file being processed.
     asset: AssetFile,
-    /// Optional type attribute (like type="image/x-icon")
-    icon_type: Option<String>,
-    /// Optional sizes attribute
-    sizes: Option<String>,
+    /// Optional media attribute
+    media: Option<String>,
 }
 
-impl Icon {
-    pub const TYPE_ICON: &'static str = "icon";
+impl AppleTouchStartupImage {
+    pub const TYPE_APPLE_TOUCH_STARTUP_IMAGE: &'static str = "apple-touch-startup-image";
 
     pub async fn new(cfg: Arc<RtcBuild>, html_dir: Arc<PathBuf>, attrs: LinkAttrs, id: usize) -> Result<Self> {
         // Build the path to the target asset.
         let href_attr = attrs
             .get(ATTR_HREF)
-            .context(r#"required attr `href` missing for <link data-trunk rel="icon" .../> element"#)?;
+            .context(r#"required attr `href` missing for <link data-trunk rel="apple-touch-startup-image" .../> element"#)?;
         let mut path = PathBuf::new();
         path.extend(href_attr.split('/'));
         let asset = AssetFile::new(&html_dir, path).await?;
-        let icon_type = attrs.get("type").map(|x| x.to_owned());
-        let sizes = attrs.get("sizes").map(|x| x.to_owned());
-        Ok(Self { id, cfg, asset, icon_type, sizes })
+        let media = attrs.get("media").map(|x| x.to_owned());
+        Ok(Self { id, cfg, asset, media })
     }
 
     /// Spawn the pipeline for this asset type.
@@ -51,44 +48,38 @@ impl Icon {
     #[tracing::instrument(level = "trace", skip(self))]
     async fn run(self) -> Result<TrunkLinkPipelineOutput> {
         let rel_path = crate::common::strip_prefix(&self.asset.path);
-        tracing::info!(path = ?rel_path, "copying & hashing icon");
+        tracing::info!(path = ?rel_path, "copying & hashing apple-touch-startup-image");
         let hashed_file_output = self.asset.copy_with_hash(&self.cfg.staging_dist).await?;
-        tracing::info!(path = ?rel_path, "finished copying & hashing icon");
-        Ok(TrunkLinkPipelineOutput::Icon(IconOutput {
+        tracing::info!(path = ?rel_path, "finished copying & hashing apple-touch-startup-image");
+        Ok(TrunkLinkPipelineOutput::AppleTouchStartupImage(AppleTouchStartupImageOutput {
             cfg: self.cfg.clone(),
             id: self.id,
             file: hashed_file_output,
-            icon_type: self.icon_type,
-            sizes: self.sizes,
+            media: self.media,
         }))
     }
 }
 
-/// The output of an Icon build pipeline.
-pub struct IconOutput {
+/// The output of an AppleTouchStartupImage build pipeline.
+pub struct AppleTouchStartupImageOutput {
     /// The runtime build config.
     pub cfg: Arc<RtcBuild>,
     /// The ID of this pipeline.
     pub id: usize,
     /// Data on the finalized output file.
     pub file: HashedFileOutput,
-    /// Optional type attribute (like type="image/x-icon")
-    pub icon_type: Option<String>,
-    /// Optional sizes attribute
-    pub sizes: Option<String>,
+    /// Optional media attribute
+    pub media: Option<String>,
 }
 
-impl IconOutput {
+impl AppleTouchStartupImageOutput {
     pub async fn finalize(self, dom: &mut Document) -> Result<()> {
         let mut opts: Vec<String> = vec![];
-        if let Some(icon_type) = self.icon_type {
-            opts.push(format!("type=\"{}\"", icon_type));
-        }
-        if let Some(sizes) = self.sizes {
-            opts.push(format!("sizes=\"{}\"", sizes));
+        if let Some(media) = self.media {
+            opts.push(format!("media=\"{}\"", media));
         }
         dom.select(&super::trunk_id_selector(self.id)).replace_with_html(format!(
-            r#"<link rel="icon" href="{base}{file}" {optional}/>"#,
+            r#"<link rel="apple-touch-startup-image" href="{base}{file}" {optional}/>"#,
             base = &self.cfg.public_url,
             file = self.file.file_name,
             optional = opts.join(" "),

--- a/src/pipelines/manifest.rs
+++ b/src/pipelines/manifest.rs
@@ -1,4 +1,4 @@
-//! Icon asset pipeline.
+//! Manifest asset pipeline (https://www.w3.org/TR/appmanifest/)
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -11,34 +11,28 @@ use super::ATTR_HREF;
 use super::{AssetFile, HashedFileOutput, LinkAttrs, TrunkLinkPipelineOutput};
 use crate::config::RtcBuild;
 
-/// An Icon asset pipeline.
-pub struct Icon {
+/// A manifest asset pipeline.
+pub struct Manifest {
     /// The ID of this pipeline's source HTML element.
     id: usize,
     /// Runtime build config.
     cfg: Arc<RtcBuild>,
     /// The asset file being processed.
     asset: AssetFile,
-    /// Optional type attribute (like type="image/x-icon")
-    icon_type: Option<String>,
-    /// Optional sizes attribute
-    sizes: Option<String>,
 }
 
-impl Icon {
-    pub const TYPE_ICON: &'static str = "icon";
+impl Manifest {
+    pub const TYPE_MANIFEST: &'static str = "manifest";
 
     pub async fn new(cfg: Arc<RtcBuild>, html_dir: Arc<PathBuf>, attrs: LinkAttrs, id: usize) -> Result<Self> {
         // Build the path to the target asset.
         let href_attr = attrs
             .get(ATTR_HREF)
-            .context(r#"required attr `href` missing for <link data-trunk rel="icon" .../> element"#)?;
+            .context(r#"required attr `href` missing for <link data-trunk rel="manifest" .../> element"#)?;
         let mut path = PathBuf::new();
         path.extend(href_attr.split('/'));
         let asset = AssetFile::new(&html_dir, path).await?;
-        let icon_type = attrs.get("type").map(|x| x.to_owned());
-        let sizes = attrs.get("sizes").map(|x| x.to_owned());
-        Ok(Self { id, cfg, asset, icon_type, sizes })
+        Ok(Self { id, cfg, asset })
     }
 
     /// Spawn the pipeline for this asset type.
@@ -51,47 +45,33 @@ impl Icon {
     #[tracing::instrument(level = "trace", skip(self))]
     async fn run(self) -> Result<TrunkLinkPipelineOutput> {
         let rel_path = crate::common::strip_prefix(&self.asset.path);
-        tracing::info!(path = ?rel_path, "copying & hashing icon");
+        tracing::info!(path = ?rel_path, "copying & hashing manifest");
         let hashed_file_output = self.asset.copy_with_hash(&self.cfg.staging_dist).await?;
-        tracing::info!(path = ?rel_path, "finished copying & hashing icon");
-        Ok(TrunkLinkPipelineOutput::Icon(IconOutput {
+        tracing::info!(path = ?rel_path, "finished copying & hashing manifest");
+        Ok(TrunkLinkPipelineOutput::Manifest(ManifestOutput {
             cfg: self.cfg.clone(),
             id: self.id,
             file: hashed_file_output,
-            icon_type: self.icon_type,
-            sizes: self.sizes,
         }))
     }
 }
 
 /// The output of an Icon build pipeline.
-pub struct IconOutput {
+pub struct ManifestOutput {
     /// The runtime build config.
     pub cfg: Arc<RtcBuild>,
     /// The ID of this pipeline.
     pub id: usize,
     /// Data on the finalized output file.
     pub file: HashedFileOutput,
-    /// Optional type attribute (like type="image/x-icon")
-    pub icon_type: Option<String>,
-    /// Optional sizes attribute
-    pub sizes: Option<String>,
 }
 
-impl IconOutput {
+impl ManifestOutput {
     pub async fn finalize(self, dom: &mut Document) -> Result<()> {
-        let mut opts: Vec<String> = vec![];
-        if let Some(icon_type) = self.icon_type {
-            opts.push(format!("type=\"{}\"", icon_type));
-        }
-        if let Some(sizes) = self.sizes {
-            opts.push(format!("sizes=\"{}\"", sizes));
-        }
         dom.select(&super::trunk_id_selector(self.id)).replace_with_html(format!(
-            r#"<link rel="icon" href="{base}{file}" {optional}/>"#,
+            r#"<link rel="manifest" href="{base}{file}"/>"#,
             base = &self.cfg.public_url,
-            file = self.file.file_name,
-            optional = opts.join(" "),
+            file = self.file.file_name
         ));
         Ok(())
     }


### PR DESCRIPTION
### Motivation
This PR tries to extend asset generation pipelines a bit towards the standards a modern PWA requirements

General reference: https://sympli.io/blog/heres-everything-you-need-to-know-about-favicons-in-2020/

### What was changed
- Changed properties of `rel=icon` link handling, they are extended with optional `sizes`, `type` attributes
- Added pipeline for web application manifest reference aka `rel=manifest` link
- Added pipelines for `rel=apple-touch-icon`, `rel=apple-touch-icon-precomposed`, `rel=apple-touch-startup-image` asset generation

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [ ] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will `:)`.
