### PR TITLE
add autoreload to `trunk serve`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 ### added
 - Closed [#139](https://github.com/thedodd/trunk/issues/139): Download and manage external applications (namely `wasm-bindgen` and `wasm-opt`) automatically. If available in the right version, system installed binaries are used but if absent the right version is downloaded and installed. This allows to use trunk without the extra steps of downloading the needed binaries manually.
 - Added an example application for using Trunk with a vanilla (no frameworks) Rust application.
+- Added `trunk serve` autoreload triggered over websocket that reloads the page when a change is detected. The `--no-autoreload` flag disables this feature.
 
 ### changed
 - `wasm-opt` is now enabled by default (with default optimization level) as the binary is automatically downloaded and installed by trunk. It can still be disabled by setting `data-wasm-opt` to `0`.

--- a/src/autoreload.js
+++ b/src/autoreload.js
@@ -1,0 +1,9 @@
+(function () {
+    var ws = new WebSocket('ws://' + window.location.host + '/_trunk/ws');
+    ws.onmessage = (ev) => {
+        const msg = JSON.parse(ev.data);
+        if (msg.reload) {
+            window.location.reload();
+        }
+    };
+})()

--- a/src/cmd/watch.rs
+++ b/src/cmd/watch.rs
@@ -22,7 +22,7 @@ impl Watch {
     pub async fn run(self, config: Option<PathBuf>) -> Result<()> {
         let (shutdown_tx, _shutdown_rx) = broadcast::channel(1);
         let cfg = ConfigOpts::rtc_watch(self.build, self.watch, config)?;
-        let mut system = WatchSystem::new(cfg, shutdown_tx.clone()).await?;
+        let mut system = WatchSystem::new(cfg, shutdown_tx.clone(), None).await?;
 
         let _res = system.build().await;
         let system_handle = tokio::spawn(system.run());

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -62,6 +62,10 @@ pub struct ConfigOptsServe {
     #[structopt(long = "proxy-ws")]
     #[serde(default)]
     pub proxy_ws: bool,
+    /// Whether to disable auto-reload of the web page when a build completes.
+    #[structopt(long = "no-autoreload")]
+    #[serde(default)]
+    pub no_autoreload: bool,
 }
 
 /// Config options for the serve system.
@@ -222,6 +226,7 @@ impl ConfigOpts {
             proxy_backend: cli.proxy_backend,
             proxy_rewrite: cli.proxy_rewrite,
             proxy_ws: cli.proxy_ws,
+            no_autoreload: cli.no_autoreload,
         };
         let cfg = ConfigOpts {
             build: None,

--- a/src/config/rt.rs
+++ b/src/config/rt.rs
@@ -130,6 +130,8 @@ pub struct RtcServe {
     pub proxy_ws: bool,
     /// Any proxies configured to run along with the server.
     pub proxies: Option<Vec<ConfigOptsProxy>>,
+    /// Whether to disable auto-reload of the web page when a build completes.
+    pub no_autoreload: bool,
 }
 
 impl RtcServe {
@@ -146,6 +148,7 @@ impl RtcServe {
             proxy_rewrite: opts.proxy_rewrite,
             proxy_ws: opts.proxy_ws,
             proxies,
+            no_autoreload: opts.no_autoreload,
         })
     }
 }


### PR DESCRIPTION
Thanks for building trunk! It's such an awesome tool. 

I took a pass at implementing a simple autoreload that is triggered by an injected websocket script. It is exposed by a `--autoreload` flag that defaults to false. It looks like my rustfmt did some collateral formatting in a couple of files, I can manually revert it if need be.

Let me know what you think!

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [x] Updated README.md with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will `:)`.
