### PR TITLE
ConfigOptsBuild.public_url: do not sanitize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 ## Unreleased
 - Added an example application for using Trunk with a vanilla (no frameworks) Rust application.
+- Avoid sanitization of the given `public_url`, to allow for relative URL.
 
 ## 0.11.0
 ### added

--- a/src/common.rs
+++ b/src/common.rs
@@ -18,13 +18,6 @@ lazy_static::lazy_static! {
     static ref CWD: PathBuf = std::env::current_dir().expect("error getting current dir");
 }
 
-/// Ensure the given value for `--public-url` is formatted correctly.
-pub fn parse_public_url(val: &str) -> String {
-    let prefix = if !val.starts_with('/') { "/" } else { "" };
-    let suffix = if !val.ends_with('/') { "/" } else { "" };
-    format!("{}{}{}", prefix, val, suffix)
-}
-
 /// A utility function to recursively copy a directory.
 pub async fn copy_dir_recursive(from_dir: PathBuf, to_dir: PathBuf) -> Result<()> {
     if !path_exists(&from_dir).await? {

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -6,7 +6,6 @@ use http_types::Url;
 use serde::Deserialize;
 use structopt::StructOpt;
 
-use crate::common::parse_public_url;
 use crate::config::{RtcBuild, RtcClean, RtcServe, RtcWatch};
 
 /// Config options for the build system.
@@ -23,7 +22,7 @@ pub struct ConfigOptsBuild {
     #[structopt(short, long, parse(from_os_str))]
     pub dist: Option<PathBuf>,
     /// The public URL from which assets are to be served [default: /]
-    #[structopt(long, parse(from_str=parse_public_url))]
+    #[structopt(long)]
     pub public_url: Option<String>,
 }
 

--- a/src/pipelines/rust_app.rs
+++ b/src/pipelines/rust_app.rs
@@ -306,9 +306,10 @@ impl RustAppOutput {
         dom.select(head).append_html(preload);
 
         let script = format!(
-            r#"<script type="module">import init from '{base}{js}';init('{base}{wasm}');</script>"#,
-            base = base,
+            r#"<script type="module">import init from '{js_base}{js}';init('{wasm_base}{wasm}');</script>"#,
+            js_base = if base.starts_with("/") { base.to_owned() } else { format!("./{}", base) },
             js = js,
+            wasm_base = base,
             wasm = wasm,
         );
         match self.id {


### PR DESCRIPTION
I'm unable to `trunk build` with a public relative url, as `parse_public_url` stubbornly prepends a slash.
By avoiding at all to parse it, it makes my use case work, and doesn't change the default modus operandi.

This special parsing was introduced in fdd8e0a0, at the time, there wasn't already the special `<base>` handling.
If one wants to reduce friction with HTML standard, this element can pretty much [accept any href value](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base) (as relative URL can be a single path component, so any filename/string would work).

A better fix would be to parse it as a real URL, but it doesn't seems that `http_types` allows for relative ones,
so it would mean changing to a crate having better URL support (such as `http`), but I didn't wanted to rewrite too much code :)

**Checklist**

- [x] Updated CHANGELOG.md describing pertinent changes.
- [x] ~~Updated README.md with pertinent info (may~~ not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will `:)`.
