### PR TITLE
more flexible version test for wasm-opt

### DIFF
--- a/src/tools.rs
+++ b/src/tools.rs
@@ -154,7 +154,7 @@ async fn find_system(app: Application, version: &str) -> Option<PathBuf> {
 
         let system_version = match app {
             Application::WasmBindgen => text.splitn(2, ' ').nth(1).context("missing version")?.to_owned(),
-            Application::WasmOpt => text.splitn(2, ' ').nth(1).context("missing version")?.replace(' ', "_"),
+            Application::WasmOpt => format!("version_{}", text.split(' ').nth(2).context("missing version")?),
         };
 
         Ok((path, system_version))


### PR DESCRIPTION
This supports the `--version` output both from binary releases of wasm-opt and from wasm-opt built from source.

I'm not sure of the reason for having `version_` in this string rather than having it just be the version number and putting `version_` in the URL, so I kept it this way. This also has the advantage of not changing the version string, so that any pre-existing cached wasm-opt would still be used.

Fixes #214 