### PR TITLE
Update & isolate version checking & formatting of version output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 - Added a new `proxy` example which demonstrates all functionality of the Trunk proxy system.
 - Fixed [#209](https://github.com/thedodd/trunk/issues/209) where the default Rust App pipeline was causing wasm-opt to be used even for debug builds when the Rust App HTML link was being omitted.
 - Closed [#168](https://github.com/thedodd/trunk/issues/158): RSS feed for blog.
+- Isolated code used for version checking & formatting of version output for downloadable applications (wasm-bindgen & wasm-opt). Added unit tests to cover this logic.
 
 ## 0.12.1
 ### fixed


### PR DESCRIPTION
This changeset isolates the code which defines the version test to use
for various downloadable applications, and also isolates the code used
to format the version output. This allows for easier unit testing of
this logic.

Added unit tests for variations of wasm-bindgen & wasm-opt version
output which differs based on installation of pre-compiled binaries vs
building from source.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [x] Updated README.md with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will `:)`.
