### PR TITLE
Only use wasm-opt when in release mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 - Fixed [#209](https://github.com/thedodd/trunk/issues/209) where the default Rust App pipeline was causing wasm-opt to be used even for debug builds when the Rust App HTML link was being omitted.
 - Closed [#168](https://github.com/thedodd/trunk/issues/158): RSS feed for blog.
 - Isolated code used for version checking & formatting of version output for downloadable applications (wasm-bindgen & wasm-opt). Added unit tests to cover this logic.
+- Fixed [#197](https://github.com/thedodd/trunk/issues/197) & [#175](https://github.com/thedodd/trunk/pull/175) where disabling wasm-opt for debug builds while keeping it enable for release builds was not possible without some hacking. Now, wasm-opt will only be used for release builds and only when enabled. This semantically matches cargo's behavior with optimizations in release mode.
 
 ## 0.12.1
 ### fixed

--- a/examples/vanilla/index.html
+++ b/examples/vanilla/index.html
@@ -10,6 +10,6 @@
     <base data-trunk-public-url/>
 </head>
 <body>
-    <link data-trunk rel="rust" href="Cargo.toml" data-bin="vanilla-example"/>
+    <link data-trunk rel="rust" href="Cargo.toml" data-wasm-opt="z" data-bin="vanilla-example"/>
 </body>
 </html>

--- a/examples/yew/index.html
+++ b/examples/yew/index.html
@@ -14,6 +14,6 @@
     <base data-trunk-public-url/>
 </head>
 <body>
-    <link data-trunk rel="rust" href="Cargo.toml" data-bin="yew-example" data-cargo-features="demo-abc,demo-xyz"/>
+    <link data-trunk rel="rust" href="Cargo.toml" data-wasm-opt="z" data-bin="yew-example" data-cargo-features="demo-abc,demo-xyz"/>
 </body>
 </html>

--- a/site/content/assets.md
+++ b/site/content/assets.md
@@ -17,8 +17,8 @@ This will typically look like: `<link data-trunk rel="{type}" href="{path}" ..ot
   - `href`: (optional) the path to the `Cargo.toml` of the Rust project. If a directory is specified, then Trunk will look for the `Cargo.toml` in the given directory. If no value is specified, then Trunk will look for a `Cargo.toml` in the parent directory of the source HTML file.
   - `data-bin`: (optional) the name of the binary to compile and use as the main WASM application. If the Cargo project has multiple binaries, this value will be required for proper functionality.
   - `data-cargo-features`: (optional) Space or comma separated list of cargo features to activate.
-  - `data-wasm-opt`: (optional) run wasm-opt with the set optimization level. The possible values are `0`, `1`, `2`, `3`, `4`, `s`, `z` or an _empty value_ for wasm-opt's default. Set this option to `0` to disable wasm-opt explicitly. The values `1-4` are increasingly stronger optimization levels for speed. `s` and `z` (z means more optimization) optimize for binary size instead.
-  - `data-keep-debug`: (optional) instruct `wasm-bindgen` to preserve debug info in the final WASM output, even for `--release` mode.
+  - `data-wasm-opt`: (optional) run wasm-opt with the set optimization level. The possible values are `0`, `1`, `2`, `3`, `4`, `s`, `z` or an _empty value_ for wasm-opt's default. Set this option to `0` to disable wasm-opt explicitly. The values `1-4` are increasingly stronger optimization levels for speed. `s` and `z` (z means more optimization) optimize for binary size instead. Only used in `--release` mode.
+  - `data-keep-debug`: (optional) instruct `wasm-bindgen` to preserve debug info in the final WASM output, even for `--release` mode. This may conflict with the use of wasm-opt, so to be sure, it is recommended to set `data-wasm-opt="0"` when using this option.
   - `data-no-demangle`: (optional) instruct `wasm-bindgen` to not demangle Rust symbol names.
 
 ## sass/scss

--- a/src/pipelines/rust_app.rs
+++ b/src/pipelines/rust_app.rs
@@ -272,6 +272,11 @@ impl RustApp {
 
     #[tracing::instrument(level = "trace", skip(self, hashed_name))]
     async fn wasm_opt_build(&self, hashed_name: &str) -> Result<()> {
+        // If not in release mode, we skip calling wasm-opt.
+        if !self.cfg.release {
+            return Ok(());
+        }
+
         // If opt level is off, we skip calling wasm-opt as it wouldn't have any effect.
         if self.wasm_opt == WasmOptLevel::Off {
             return Ok(());


### PR DESCRIPTION
This addresses a few pain points where there was no way to reasonably
disable wasm-opt use for debug builds while keeping it enabled for
release builds. There seems to be very few (if any) use cases for using
wasm-opt on a debug build, as such, wasm-opt is now only run on release
builds when enabled.

closes #197
closes #175

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [x] Updated README.md with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will `:)`.
