### PR TITLE
Automatically reconnect to the auto-reload socket

### DIFF
--- a/src/autoreload.js
+++ b/src/autoreload.js
@@ -1,9 +1,26 @@
 (function () {
-    var ws = new WebSocket('ws://' + window.location.host + '/_trunk/ws');
+    var url = 'ws://' + window.location.host + '/_trunk/ws';
+    var poll_interval = 5000;
+    var reload_upon_connect = () => {
+        window.setTimeout(
+            () => {
+                // when we successfully reconnect, we'll force a
+                // reload (since we presumably lost connection to
+                // trunk due to it being killed, so it will have
+                // rebuilt on restart)
+                var ws = new WebSocket(url);
+                ws.onopen = () => window.location.reload();
+                ws.onclose = reload_upon_connect;
+            },
+            poll_interval);
+    };
+
+    var ws = new WebSocket(url);
     ws.onmessage = (ev) => {
         const msg = JSON.parse(ev.data);
         if (msg.reload) {
             window.location.reload();
         }
     };
+    ws.onclose = reload_upon_connect;
 })()


### PR DESCRIPTION
If we're disconnected (for example, if the user ^Cs trunk) try to
reconnect every five seconds until successful, whereupon reload to
ensure we've got the latest code.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [ ] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [ ] Updated `site` content with pertinent info (may not always apply).
- [ ] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
