### PR TITLE
Shut down proxied websockets more promptly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 - Download and use the official `dart-sass` binary for SASS/SCSS to CSS compilation. This allows to
   always support the latest features and will allow to make Trunk available for futher platforms in
   the future as this removes the dependency on `sass-rs`.
+- Proxied websockets now shut down immediately upon completion of streaming data in either direction, instead of waiting for completion of both directions.
 
 ## 0.13.1
 - Fixed [#219](https://github.com/thedodd/trunk/issues/219): Preserve websocket message types when sending to the backend.

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -212,7 +212,11 @@ impl ProxyHandlerWebSocket {
             }
         };
 
-        futures::join!(stream_to_backend, stream_to_frontend);
+        tokio::select! {
+            _ = stream_to_backend => (),
+            _ = stream_to_frontend => ()
+        };
+
         tracing::debug!("websocket connection closed");
     }
 }


### PR DESCRIPTION
Before, it would wait for both the `stream_to_frontend` and
`stream_to_backend` futures to complete before shutting down the socket,
but once either side is broken there's no point in continuing with
the other.

In particular, this allows the browser to immediately notice when a
backend server is restarted, instead of delaying until it tries to
send a message.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [X] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [ ] Updated `site` content with pertinent info (may not always apply).
- [ ] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
