### PR TITLE
Error overlay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi-to-html"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ee82de0545b181a17cbdef44fce80ecaf394e001da7ea279008bf2e0944bee"
+dependencies = [
+ "regex",
+ "thiserror",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2270,6 +2280,7 @@ dependencies = [
 name = "trunk"
 version = "0.13.1"
 dependencies = [
+ "ansi-to-html",
  "ansi_term 0.12.1",
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2294,6 +2294,7 @@ dependencies = [
  "reqwest",
  "seahash",
  "serde",
+ "serde_json",
  "structopt",
  "structopt-derive",
  "tar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ remove_dir_all = "0.6"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "stream", "trust-dns"] }
 seahash = "4"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 structopt = "0.3"
 structopt-derive = "0.4"
 tar = "0.4.35"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ codegen-units = 1
 panic = "abort"
 
 [dependencies]
+ansi-to-html = "0.1.0"
 ansi_term = "0.12"
 anyhow = "1"
 axum = { version = "0.1", features = ["ws"] }
@@ -37,7 +38,11 @@ notify = "5.0.0-pre.11"
 once_cell = "1.8.0"
 open = "1"
 remove_dir_all = "0.6"
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "stream", "trust-dns"] }
+reqwest = { version = "0.11", default-features = false, features = [
+    "rustls-tls",
+    "stream",
+    "trust-dns",
+] }
 seahash = "4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -46,7 +51,13 @@ structopt-derive = "0.4"
 tar = "0.4.35"
 # See https://docs.rs/tokio/latest/tokio/#feature-flags - we basically use all of the features.
 tokio = { version = "1", default-features = false, features = ["full"] }
-tokio-stream = { version = "0.1", default-features = false, features = ["fs", "time", "net", "signal", "sync"] }
+tokio-stream = { version = "0.1", default-features = false, features = [
+    "fs",
+    "time",
+    "net",
+    "signal",
+    "sync",
+] }
 tokio-tar = "0.3"
 tokio-tungstenite = "0.14"
 toml = "0.5"

--- a/src/pipelines/html.rs
+++ b/src/pipelines/html.rs
@@ -17,7 +17,7 @@ use crate::pipelines::rust_app::RustApp;
 use crate::pipelines::{LinkAttrs, PipelineStage, TrunkLink, TrunkLinkPipelineOutput, TRUNK_ID};
 
 const PUBLIC_URL_MARKER_ATTR: &str = "data-trunk-public-url";
-const RELOAD_SCRIPT: &str = include_str!("../autoreload.js");
+const WS_CLIENT_SCRIPT: &str = include_str!("../ws_client.js");
 
 type AssetPipelineHandles = FuturesUnordered<JoinHandle<Result<TrunkLinkPipelineOutput>>>;
 
@@ -148,11 +148,11 @@ impl HtmlPipeline {
         base_elements.remove_attr(PUBLIC_URL_MARKER_ATTR);
         base_elements.set_attr("href", &self.cfg.public_url);
 
-        // Inject the WebSocket autoloader.
+        // Inject the WebSocket client.
         if self.cfg.inject_autoloader {
             target_html
                 .select("body")
-                .append_html(format!("<script>{}</script>", RELOAD_SCRIPT));
+                .append_html(format!("<script>{}</script>", WS_CLIENT_SCRIPT));
         }
     }
 }

--- a/src/pipelines/rust_app.rs
+++ b/src/pipelines/rust_app.rs
@@ -130,6 +130,7 @@ impl RustApp {
         let mut args = vec![
             "build",
             "--target=wasm32-unknown-unknown",
+            "--color=always",
             "--manifest-path",
             &self.manifest.manifest_path,
         ];

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -28,12 +28,12 @@ pub struct WatchSystem {
     /// The application shutdown channel.
     shutdown: BroadcastStream<()>,
     /// Channel that is sent on whenever a build completes.
-    build_done_tx: Option<broadcast::Sender<()>>,
+    build_done_chan: Option<broadcast::Sender<()>>,
 }
 
 impl WatchSystem {
     /// Create a new instance.
-    pub async fn new(cfg: Arc<RtcWatch>, shutdown: broadcast::Sender<()>, build_done_tx: Option<broadcast::Sender<()>>) -> Result<Self> {
+    pub async fn new(cfg: Arc<RtcWatch>, shutdown: broadcast::Sender<()>, build_done_chan: Option<broadcast::Sender<()>>) -> Result<Self> {
         // Create a channel for being able to listen for new paths to ignore while running.
         let (watch_tx, watch_rx) = mpsc::channel(1);
         let (build_tx, build_rx) = mpsc::channel(1);
@@ -50,7 +50,7 @@ impl WatchSystem {
             build_rx,
             _watcher,
             shutdown: BroadcastStream::new(shutdown.subscribe()),
-            build_done_tx,
+            build_done_chan,
         })
     }
 
@@ -110,7 +110,7 @@ impl WatchSystem {
 
             // TODO/NOTE: in the future, we will want to be able to pass along error info and other
             // diagnostics info over the socket for use in an error overlay or console logging.
-            if let Some(tx) = self.build_done_tx.as_mut() {
+            if let Some(tx) = self.build_done_chan.as_mut() {
                 let _ = tx.send(());
             }
 

--- a/src/ws_client.js
+++ b/src/ws_client.js
@@ -24,7 +24,7 @@
             window.location.reload();
         } else if (data.status == "failed") {
             console.error("[TRUNK]: Build failed.");
-            console.error(data.message);
+            document.body.innerHTML = data.message;
         } else {
             console.error("[TRUNK]: Internal error, malformed data", data);
         }

--- a/src/ws_client.js
+++ b/src/ws_client.js
@@ -17,15 +17,16 @@
 
     var ws = new WebSocket(url);
     ws.onmessage = (ev) => {
-        const msg = JSON.parse(ev.data);
-        if (msg.status == "started") {
+        const data = JSON.parse(ev.data);
+        if (data.status == "started") {
             console.log("[TRUNK]: Build started.");
-        } else if (msg.status == "succeeded") {
+        } else if (data.status == "succeeded") {
             window.location.reload();
-        } else if (msg.status == "failed") {
+        } else if (data.status == "failed") {
             console.error("[TRUNK]: Build failed.");
+            console.error(data.message);
         } else {
-            console.error("[TRUNK]: Internal error, unknown status", status);
+            console.error("[TRUNK]: Internal error, malformed data", data);
         }
     };
     ws.onclose = reload_upon_connect;

--- a/src/ws_client.js
+++ b/src/ws_client.js
@@ -25,6 +25,7 @@
         } else if (data.status == "failed") {
             console.error("[TRUNK]: Build failed.");
             document.body.innerHTML = data.message;
+            document.body.style.whiteSpace = "pre-wrap"
         } else {
             console.error("[TRUNK]: Internal error, malformed data", data);
         }

--- a/src/ws_client.js
+++ b/src/ws_client.js
@@ -18,8 +18,14 @@
     var ws = new WebSocket(url);
     ws.onmessage = (ev) => {
         const msg = JSON.parse(ev.data);
-        if (msg.reload) {
+        if (msg.status == "started") {
+            console.log("[TRUNK]: Build started.");
+        } else if (msg.status == "succeeded") {
             window.location.reload();
+        } else if (msg.status == "failed") {
+            console.error("[TRUNK]: Build failed.");
+        } else {
+            console.error("[TRUNK]: Internal error, unknown status", status);
         }
     };
     ws.onclose = reload_upon_connect;


### PR DESCRIPTION
Closes #141 

This PR introduces `NewBuildStatusMsg` which is sent on the build status broadcast channel whenever the build status changes.
The build status can be 3 distinct values:
- started
- succeeded
- failed

The started message is so that we can `console.log` a message in the browser to notify the user that what they are currently seeing is not up to date yet.
The succeeded message is to trigger a reload in the browser.
The failed message is to show an error overlay in the browser.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [ ] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [ ] Updated `site` content with pertinent info (may not always apply).
- [ ] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
