### PR TITLE
Add support for reference types & weak references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 - Added the `--proxy-insecure` option for `trunk serve`.
 - Added the `insecure` option to the `proxy` section in `Trunk.toml`.
 - It is now possible to disable the hashes in output file names with the new `--filehash` flag (for example `cargo build --filehash false`). Alternatively the `build.filehash` setting in `Trunk.toml` or the env var `CARGO_BUILD_FILEHASH` can be used.
+- Flags for enabling reference types & weak references in `wasm-bindgen`.
 
 ### changed
 - Bump notify to 5.0.0-pre.13, which fixes [notify-rs/notify#356](https://github.com/notify-rs/notify/issues/356)

--- a/site/content/assets.md
+++ b/site/content/assets.md
@@ -21,6 +21,8 @@ This will typically look like: `<link data-trunk rel="{type}" href="{path}" ..ot
   - `data-wasm-opt`: (optional) run wasm-opt with the set optimization level. The possible values are `0`, `1`, `2`, `3`, `4`, `s`, `z` or an _empty value_ for wasm-opt's default. Set this option to `0` to disable wasm-opt explicitly. The values `1-4` are increasingly stronger optimization levels for speed. `s` and `z` (z means more optimization) optimize for binary size instead. Only used in `--release` mode.
   - `data-keep-debug`: (optional) instruct `wasm-bindgen` to preserve debug info in the final WASM output, even for `--release` mode. This may conflict with the use of wasm-opt, so to be sure, it is recommended to set `data-wasm-opt="0"` when using this option.
   - `data-no-demangle`: (optional) instruct `wasm-bindgen` to not demangle Rust symbol names.
+  - `data-reference-types`: (optional) instruct `wasm-bindgen` to enable [reference types](https://rustwasm.github.io/docs/wasm-bindgen/reference/reference-types.html).
+  - `data-weak-refs`: (optional) instruct `wasm-bindgen` to enable [weak references](https://rustwasm.github.io/docs/wasm-bindgen/reference/weak-references.html).
 
 ## sass/scss
 ✅ `rel="sass"` or `rel="scss"`: Trunk uses the official [dart-sass](https://github.com/sass/dart-sass) for compilation. Just link to your sass files from your source HTML, and Trunk will handle the rest. This content is hashed for cache control. The `href` attribute must be included in the link pointing to the sass/scss file to be processed.

--- a/src/pipelines/rust.rs
+++ b/src/pipelines/rust.rs
@@ -42,6 +42,10 @@ pub struct RustApp {
     keep_debug: bool,
     /// An option to instruct wasm-bindgen to not demangle Rust symbol names.
     no_demangle: bool,
+    /// An option to instruct wasm-bindgen to enable reference types.
+    reference_types: bool,
+    /// An option to instruct wasm-bindgen to enable weak references.
+    weak_refs: bool,
     /// An optional optimization setting that enables wasm-opt. Can be nothing, `0` (default), `1`,
     /// `2`, `3`, `4`, `s or `z`. Using `0` disables wasm-opt completely.
     wasm_opt: WasmOptLevel,
@@ -108,6 +112,9 @@ impl RustApp {
             .map(|s| s.as_str())
             .unwrap_or("main")
             .parse()?;
+        let app_type = attrs.get("data-type").map(|s| s.as_str()).unwrap_or("main").parse()?;
+        let reference_types = attrs.contains_key("data-reference-types");
+        let weak_refs = attrs.contains_key("data-weak-refs");
         let wasm_opt = attrs
             .get("data-wasm-opt")
             .map(|val| val.parse())
@@ -132,6 +139,8 @@ impl RustApp {
             bin,
             keep_debug,
             no_demangle,
+            reference_types,
+            weak_refs,
             wasm_opt,
             app_type,
             name,
@@ -156,6 +165,8 @@ impl RustApp {
             bin: None,
             keep_debug: false,
             no_demangle: false,
+            reference_types: false,
+            weak_refs: false,
             wasm_opt: WasmOptLevel::Off,
             app_type: RustAppType::Main,
             name,
@@ -319,6 +330,12 @@ impl RustApp {
         }
         if self.no_demangle {
             args.push("--no-demangle");
+        }
+        if self.reference_types {
+            args.push("--reference-types");
+        }
+        if self.weak_refs {
+            args.push("--weak-refs");
         }
 
         // Invoke wasm-bindgen.

--- a/src/pipelines/rust.rs
+++ b/src/pipelines/rust.rs
@@ -112,7 +112,6 @@ impl RustApp {
             .map(|s| s.as_str())
             .unwrap_or("main")
             .parse()?;
-        let app_type = attrs.get("data-type").map(|s| s.as_str()).unwrap_or("main").parse()?;
         let reference_types = attrs.contains_key("data-reference-types");
         let weak_refs = attrs.contains_key("data-weak-refs");
         let wasm_opt = attrs


### PR DESCRIPTION
Pretty trivial PR to add these missing wasm-bindgen flags to trunk. I think these should be added since reference types has shipped in Firefox and are in Chrome Canary (https://www.chromestatus.com/feature/5166497248837632)

Too bad the compatibility with reference types and wasm-opt is still a bit of a hit & miss, but hopefully that will improve soon. Weak references in my projects have worked on all browsers I've tested.
