### PR TITLE
Add --hash for CLI and --typescript for wasm-bindgen

### DIFF
--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -22,6 +22,10 @@ pub struct ConfigOptsBuild {
     #[structopt(long)]
     #[serde(default)]
     pub release: bool,
+    /// Build with asset hash name [default: true]
+    #[structopt(long)]
+    #[serde(default)]
+    pub hash: bool,
     /// The output dir for all final assets [default: dist]
     #[structopt(short, long, parse(from_os_str))]
     pub dist: Option<PathBuf>,
@@ -250,6 +254,7 @@ impl ConfigOpts {
         let opts = ConfigOptsBuild {
             target: cli.target,
             release: cli.release,
+            hash: cli.hash,
             dist: cli.dist,
             public_url: cli.public_url,
             pattern_script: cli.pattern_script,

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -22,7 +22,7 @@ pub struct ConfigOptsBuild {
     #[structopt(long)]
     #[serde(default)]
     pub release: bool,
-    /// Build with asset hash name [default: true]
+    /// Build with asset hash name [default: false]
     #[structopt(long)]
     #[serde(default)]
     pub hash: bool,

--- a/src/config/rt.rs
+++ b/src/config/rt.rs
@@ -63,7 +63,7 @@ impl RtcBuild {
         // have a reliable FS path to work with, we make an exception here.
         let final_dist = opts.dist.unwrap_or_else(|| target_parent.join(super::DIST_DIR));
         if !final_dist.exists() {
-            std::fs::create_dir(&final_dist).with_context(|| format!("error creating final dist directory {:?}", &final_dist))?;
+            std::fs::create_dir_all(&final_dist).with_context(|| format!("error creating final dist directory {:?}", &final_dist))?;
         }
         let final_dist = final_dist
             .canonicalize()

--- a/src/config/rt.rs
+++ b/src/config/rt.rs
@@ -16,6 +16,8 @@ pub struct RtcBuild {
     pub target_parent: PathBuf,
     /// Build in release mode.
     pub release: bool,
+    /// Hash asset name
+    pub hash: bool,
     /// The public URL from which assets are to be served.
     pub public_url: String,
     /// The directory where final build artifacts are placed after a successful build.
@@ -72,6 +74,7 @@ impl RtcBuild {
             target,
             target_parent,
             release: opts.release,
+            hash: opts.hash,
             staging_dist,
             final_dist,
             public_url: opts.public_url.unwrap_or_else(|| "/".into()),

--- a/src/pipelines/rust_app.rs
+++ b/src/pipelines/rust_app.rs
@@ -196,10 +196,13 @@ impl RustApp {
 
         // Hash the built wasm app, then use that as the out-name param.
         tracing::info!("processing WASM");
-        let wasm_bytes = fs::read(&wasm)
-            .await
-            .context("error reading wasm file for hash generation")?;
-        let hashed_name = format!("index-{:x}", seahash::hash(&wasm_bytes));
+        let mut hashed_name:String =  self.manifest.package.name.clone();
+        if self.cfg.hash {
+            let wasm_bytes = fs::read(&wasm)
+                .await
+                .context("error reading wasm file for hash generation")?;
+           hashed_name = format!("index-{:x}", seahash::hash(&wasm_bytes));
+        }
         Ok((wasm, hashed_name))
     }
 

--- a/src/pipelines/rust_app.rs
+++ b/src/pipelines/rust_app.rs
@@ -228,7 +228,7 @@ impl RustApp {
         let arg_out_path = format!("--out-dir={}", bindgen_out.display());
         let arg_out_name = format!("--out-name={}", &hashed_name);
         let target_wasm = wasm.to_string_lossy().to_string();
-        let mut args = vec!["--target=web", &arg_out_path, &arg_out_name, "--no-typescript", &target_wasm];
+        let mut args = vec!["--target=web", &arg_out_path, &arg_out_name, "--typescript", &target_wasm];
         if self.keep_debug {
             args.push("--keep-debug");
         }
@@ -245,14 +245,20 @@ impl RustApp {
         // Copy the generated WASM & JS loader to the dist dir.
         tracing::info!("copying generated wasm-bindgen artifacts");
         let hashed_js_name = format!("{}.js", &hashed_name);
+        let hashed_js_declare_name = format!("{}.d.ts", &hashed_name);
         let hashed_wasm_name = format!("{}_bg.wasm", &hashed_name);
         let js_loader_path = bindgen_out.join(&hashed_js_name);
         let js_loader_path_dist = self.cfg.staging_dist.join(&hashed_js_name);
+        let js_declare_path =  bindgen_out.join(&hashed_js_declare_name);
+        let js_declare_path_dist = self.cfg.staging_dist.join(&hashed_js_declare_name);
         let wasm_path = bindgen_out.join(&hashed_wasm_name);
         let wasm_path_dist = self.cfg.staging_dist.join(&hashed_wasm_name);
         fs::copy(js_loader_path, js_loader_path_dist)
             .await
             .context("error copying JS loader file to stage dir")?;
+        fs::copy(js_declare_path, js_declare_path_dist)
+            .await
+            .context("error copying JS declare file to stage dir")?;
         fs::copy(wasm_path, wasm_path_dist)
             .await
             .context("error copying wasm file to stage dir")?;


### PR DESCRIPTION
Implement feature for  #136 Disable hash for release builds, and default is hash closed.  We can make hash enabled by default if necessary.

Add '--typescript' option for wasm-bindgen and copy d.ts file to dest, and d.ts file is friendly to TypeScript and debug. 