### PR TITLE
Allow binding to port 0 and on specified interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 ## Unreleased
 ### added
 - Added the `--address` option for `trunk serve`.
+- Allow binding to port 0 to let the operating system select a free port.
 - Open autoreload websocket using wss when assets are served over a secure connection.
 - Added the `data-type` attribute to Rust assets. Can be set to either `main` (previous behaviour and default) or `worker`, which builds the asset and includes it as a web worker.
 

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -19,7 +19,7 @@ ignore = []
 [serve]
 # The address to serve on.
 addr = "127.0.0.1"
-# The port to serve on.
+# The port to serve on.  Use 0 to select a port automatically.
 port = 8080
 # Open a browser tab once the initial build is complete.
 open = false


### PR DESCRIPTION
This is an alternate fix for #252 - I think it would be extremely surprising for a program which has been told to bind to port X to choose of its own accord to bind to port Y instead, so this doesn't.  Instead it makes use of the existing facility of the OS to allow the user to specifically say "I do not care what port this gets bound to, just choose one for me".

Also this also allows you to select a specific network interface  - it's still 0.0.0.0 by default but it should probably actually be a loopback interface.

Finally, this now prints a URL that you can copy and paste (or click on, if your terminal supports that) to open the application, in addition to showing the bound interface and port.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [X] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [ ] Updated `site` content with pertinent info (may not always apply).
- [X] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
