### PR TITLE
Use wss when serving over https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 ## Unreleased
 
+### added.
+- Open autoreload websocket using wss when assets are served over a secure connection.
+
 ## 0.14.0
 ### added
 - Trunk now includes a hooks system. This improves many use cases where another build tool is needed alongside trunk, by allowing trunk to be configured to call them at various stages during the build pipeline. It is configured under `[[hooks]]` in `Trunk.toml`. More information can be found in the [Assets](https://trunkrs.dev/assets/) section of the docs.

--- a/src/autoreload.js
+++ b/src/autoreload.js
@@ -1,5 +1,6 @@
 (function () {
-    var url = 'ws://' + window.location.host + '/_trunk/ws';
+    var protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    var url = protocol + '//' + window.location.host + '/_trunk/ws';
     var poll_interval = 5000;
     var reload_upon_connect = () => {
         window.setTimeout(


### PR DESCRIPTION
Automatic switch to secure websocket connection when using https. This is necessary when trunk is behind a proxy that adds https in development.

**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.