### PR TITLE
Nested WS proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 ### added
 ### changed
 ### fixed
+- Nested WS proxies - if `backend=ws://localhost:8000/ws` is set, queries for `ws://localhost:8080/ws/entityX` will be linked with `ws://localhost:8000/ws/entityX`
 
 ## 0.16.0
 ### added

--- a/src/pipelines/rust.rs
+++ b/src/pipelines/rust.rs
@@ -263,7 +263,7 @@ impl RustApp {
         }
 
         // Now propagate any errors which came from the cargo build.
-        let _ = build_res?;
+        build_res?;
 
         // Perform a final cargo invocation on success to get artifact names.
         tracing::info!("fetching cargo artifacts");


### PR DESCRIPTION
These changes are going to make WS proxied endpoint to
be treated in the same way as HTTP proxied endpoint.

This means if `backend=ws://localhost:8000/ws` is set, the queries to
`ws://localhost:8080/ws/entityX` will be forwarded to
`ws://localhost:8000/ws/entityY`.

Before that only requests directly to `ws://localhost:8080/ws`
are forwarded to `ws://localhost:8080/ws`.

My motivation for submitting this PR is that I'm using multiple WS endpoints with dynamic paths on the server.
e.g. `/ws/{customer_name}/notifications`
And trunk is not able to handle this smoothly.
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [X] Updated CHANGELOG.md describing pertinent changes.
- [X] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
