### PR TITLE
267 Rename ```copy-file``` assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This changelog follows the patterns described here: https://keepachangelog.com/e
 Subheadings to categorize changes are `added, changed, deprecated, removed, fixed, security`.
 
 ## Unreleased
+### added
+- Added optional header to link elements with ```rel="copy-file"``` called ```data-dist``` that changes the name of the file to be copied to the string supplied to the attribute.
 
 ## 0.14.0
 ### added

--- a/site/content/assets.md
+++ b/site/content/assets.md
@@ -39,6 +39,7 @@ This will typically look like: `<link data-trunk rel="{type}" href="{path}" ..ot
 
 ## copy-file
 ✅ `rel="copy-file"`: Trunk will copy the file specified in the `href` attribute to the `dist` dir. This content is copied exactly, no hashing is performed.
+  - `data-dist`: (optional) the new name you would like an asset to have after copying. Please include the correct extension. Keeps the current name if not present.
 
 ## copy-dir
 ✅ `rel="copy-dir"`: Trunk will recursively copy the directory specified in the `href` attribute to the `dist` dir. This content is copied exactly, no hashing is performed.

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -55,10 +55,11 @@ pub struct ConfigOptsBuild {
     ///
     /// When a pattern is being replaced with its corresponding value from this map, if the value is
     /// prefixed with the symbol `@`, then the value is expected to be a file path, and the pattern
-    /// will be replaced with the contents of the target file. This allows insertion of some big JSON
-    /// state or even HTML files as a part of the `index.html` build.
+    /// will be replaced with the contents of the target file. This allows insertion of some big
+    /// JSON state or even HTML files as a part of the `index.html` build.
     ///
-    /// Trunk will automatically insert the `base`, `wasm` and `js` key/values into this map. In order
+    /// Trunk will automatically insert the `base`, `wasm` and `js` key/values into this map. In
+    /// order
     //// for the app to be loaded properly, the patterns `{base}`, `{wasm}` and `{js}` should be used
     /// in `pattern_script` and `pattern_preload`.
     ///

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -37,6 +37,7 @@ const ATTR_INLINE: &str = "data-inline";
 const ATTR_HREF: &str = "href";
 const ATTR_TYPE: &str = "type";
 const ATTR_REL: &str = "rel";
+const ATTR_RENAME: &str = "data-dist";
 const SNIPPETS_DIR: &str = "snippets";
 const TRUNK_ID: &str = "data-trunk-id";
 


### PR DESCRIPTION
#### Hi all!
This is my first PR for this project, so if anything is out of line with the code I wrote, feel free to call it out. I appreciate constructive criticism.

### Overview
**Resolves #267**

Users have requested that they have the ability to change the file name when using Trunk to copy a file. This pull request is to reassign the file name-related attributes to the single FileAsset before it is written to the new directory.

**Checklist**
- [X] Updated CHANGELOG.md describing pertinent changes.
- [X] Updated README.md with pertinent info (may not always apply).
- [X] Updated `site` content with pertinent info (may not always apply).
- [X] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.

#### Manual Testing Steps
* Create a project or use a previously existing project that has a ```<link data-trunk rel="copy-file" ... />``` tag in its index.html file.
* Add the ```new-name``` attribute to it with any value you see fit (although you may run into more errors down the line if unsupported characters or file types are used).
  * ex: ```<link data-trunk rel="copy-file" href="assets/favicon.ico" new-name="bojangles.jpg" />```
* Run ```trunk serve``` or any other build command.
* Check the ```dist/``` directory (or other compilation target directory, should it differ in your environment) for your copied file with a new name.