### PR TITLE
Check for the target arch when downloading tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 - The `cargo serve` command now listens on `127.0.0.1` (localhost) instead of `0.0.0.0`, fixing security issues when on a public Wi-Fi or otherwise accessible network connection. The address can still be changed with the `Trunk.toml` or `--address` cli argument.
 - Force HTTP/1 on proxy client, which fixes [#280](https://github.com/thedodd/trunk/issues/280)
 - Print the serving address with a protocol to make it to be recognized as an URL in some terminals [#292](https://github.com/thedodd/trunk/issues/292)
+- Verify the target architecture when downloading tools in addition to the OS and fail if the architecture doesn't match.
 
 ## 0.14.0
 ### added

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -88,6 +88,8 @@ impl Application {
     /// Target for the current OS as part of the download URL. Can fail as there might be no release
     /// for the current platform.
     fn target(&self) -> Result<&str> {
+        ensure!(cfg!(target_arch = "x86_64"), "unsupported architecture");
+
         Ok(match self {
             Self::WasmBindgen => {
                 if cfg!(target_os = "windows") {


### PR DESCRIPTION
When I implemented the automatic tool download feature, I only implemented checks for the target OS but didn't think about different architecture. Discussions on Discord showed that this causes issues when for example trying to run `wasm-bindgen` from a Mac with M1 as all available tools are only pre-compiled for `x86_64`.

This change lets the tool download fail when running from a non-x86_64 architecture.

To still be able to run on different archs, the user must make sure a system-wide installation is present and matches the version appropriate for the project at hand. Maybe this should be noted somewhere in the readme or on the website?

Fixes #212 

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [x] Updated README.md with pertinent info (may not always apply).
- [x] Updated `site` content with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
