### PR TITLE
Parse version of dart2js compiled sass compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 ### changed
 - Bump notify to 5.0.0-pre.13, which fixes [notify-rs/notify#356](https://github.com/notify-rs/notify/issues/356)
+- Allow usage of dart2js compiled sass compiler
 
 ## 0.14.0
 ### added

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -152,6 +152,7 @@ impl Application {
             Application::Sass => text
                 .lines()
                 .next()
+                .and_then(|s| s.split(' ').next())// allow for dart2js compiled version
                 .with_context(|| format!("missing or malformed version output: {}", text))?
                 .to_owned(),
             Application::WasmBindgen => text
@@ -516,4 +517,11 @@ mod tests {
     );
 
     table_test_format_version!(sass_pre_compiled, Application::Sass, "1.37.5", "1.37.5");
+
+    table_test_format_version!(
+        sass_dart2js_pre_compiled,
+        Application::Sass,
+        "1.37.5 compiled with dart2js 2.14.4",
+        "1.37.5"
+    );
 }


### PR DESCRIPTION
This allows users of platforms where the dart SDK is not available
(e.g. FreeBSD) to use the dart2js version which can be installed
via `npm install -g sass`.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [ ] Updated `site` content with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
