### PR TITLE
Persist inputs data between refreshs

### DIFF
--- a/src/autoreload.js
+++ b/src/autoreload.js
@@ -24,4 +24,23 @@
         }
     };
     ws.onclose = reload_upon_connect;
+    
+    
+    // Persist inputs data between refreshs
+    const REFRESH_DATA_KEY = 'trunk-refresh-data';
+    window.onbeforeunload = (e) => {
+        localStorage.setItem(REFRESH_DATA_KEY, JSON.stringify(Array.from(document.querySelectorAll('input')).map(it => it.value)));
+    };
+    let interval = setInterval(() => {
+        try {
+            const inputs = document.querySelectorAll('input');
+            if (inputs.length) {
+                clearInterval(interval);
+                const values = JSON.parse(localStorage.getItem(REFRESH_DATA_KEY));
+                document.querySelectorAll('input').forEach((elm, i) => elm.value = values[i]);
+                clearInterval(interval);
+            }
+        } catch (_) { }
+    }, 200);
+    
 })()


### PR DESCRIPTION
**Persist inputs data between refreshs**
We could add a setting for it in Trunk.toml to disable the behavior, but i think it should be enabled by default.
The implementation is naive and breaks for inputs following an added input, but generating unique selectors meaning adding an element to the form for example breaks all the form. I think this is good enough

we can remove onbeforeunload and added it under ws.onopen next to reload, but this seperates the concerns better and works

Will update the other files to reflect the added feature if it is accepted
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [ ] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [ ] Updated `site` content with pertinent info (may not always apply).
- [ ] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
