### PR TITLE
Delete the temporary CSS output of dart-sass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 ### changed
 - Bump notify to 5.0.0-pre.13, which fixes [notify-rs/notify#356](https://github.com/notify-rs/notify/issues/356)
+- Remove the temporary output of the SASS compiler from the output directory of Trunk.
 
 ## 0.14.0
 ### added

--- a/src/pipelines/sass.rs
+++ b/src/pipelines/sass.rs
@@ -66,9 +66,10 @@ impl Sass {
 
         let rel_path = crate::common::strip_prefix(&self.asset.path);
         tracing::info!(path = ?rel_path, "compiling sass/scss");
-        common::run_command("sass", &sass, args).await?;
+        common::run_command(Application::Sass.name(), &sass, args).await?;
 
         let css = fs::read_to_string(&file_path).await?;
+        fs::remove_file(&file_path).await?;
 
         // Check if the specified SASS/SCSS file should be inlined.
         let css_ref = if self.use_inline {


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [x] Updated README.md with pertinent info (may not always apply).
- [x] Updated `site` content with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.

Currently we run `dart-sass` to compile from SASS/SCSS to CSS and save the output in Trunk's output (usually `dist`) directory. Then directly after we read the whole file into memory, hash it and save the same content back to a new file with the has value included.

We never delete that orignal output from `dart-sass` though and I think we just forgot to delete that temporary file when we switched from natively using `sass-rs`.
This PR simply deletes that temporary file. In the future we might improve the situation by redirecting the stdout of dart-sass directly to trunk and capture that content, instead of writing out to the file system.

## Example

Imagine we have a `index.sass` with some content and have `<link data-trunk rel="sass" href="index.sass">` in an `index.html`. We would get two CSS files instead of two:

```txt
dist/
  index.html
  index.css         <-- unexpected file with the same content (temporary dart-sass output)
  index-{hash}.css  <-- expected file
```

By deleting the temporary file we end up with just:


```txt
dist/
  index.html
  index-{hash}.css
```
