### PR TITLE
Support passing custom profiles to cargo

### DIFF
--- a/Trunk.toml
+++ b/Trunk.toml
@@ -5,6 +5,8 @@
 target = "index.html"
 # Build in release mode.
 release = false
+# Build with a custom profile, defined in the Cargo.toml.
+profile = "minified"
 # The output dir for all final assets.
 dist = "dist"
 # The public URL from which assets are to be served.

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -22,6 +22,9 @@ pub struct ConfigOptsBuild {
     #[structopt(long)]
     #[serde(default)]
     pub release: bool,
+    /// Build artifacts with the specified profile
+    #[structopt(long)]
+    pub profile: Option<String>,
     /// The output dir for all final assets [default: dist]
     #[structopt(short, long, parse(from_os_str))]
     pub dist: Option<PathBuf>,
@@ -253,6 +256,7 @@ impl ConfigOpts {
         let opts = ConfigOptsBuild {
             target: cli.target,
             release: cli.release,
+            profile: cli.profile,
             dist: cli.dist,
             public_url: cli.public_url,
             pattern_script: cli.pattern_script,
@@ -416,6 +420,7 @@ impl ConfigOpts {
                 if l.release {
                     g.release = true;
                 }
+                g.profile = g.profile.or(l.profile);
                 g.pattern_preload = g.pattern_preload.or(l.pattern_preload);
                 g.pattern_script = g.pattern_script.or(l.pattern_script);
                 g.pattern_params = g.pattern_params.or(l.pattern_params);

--- a/src/config/rt.rs
+++ b/src/config/rt.rs
@@ -16,6 +16,8 @@ pub struct RtcBuild {
     pub target_parent: PathBuf,
     /// Build in release mode.
     pub release: bool,
+    /// Build artifacts with the specified profile.
+    pub profile: Option<String>,
     /// The public URL from which assets are to be served.
     pub public_url: String,
     /// The directory where final build artifacts are placed after a successful build.
@@ -72,6 +74,7 @@ impl RtcBuild {
             target,
             target_parent,
             release: opts.release,
+            profile: opts.profile,
             staging_dist,
             final_dist,
             public_url: opts.public_url.unwrap_or_else(|| "/".into()),

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -24,7 +24,12 @@ pub fn spawn_hooks(cfg: Arc<RtcBuild>, stage: PipelineStage) -> HookHandles {
                 .args(&hook_cfg.command_arguments)
                 .stdout(Stdio::inherit())
                 .stderr(Stdio::inherit())
-                .env("TRUNK_PROFILE", if cfg.release { "release" } else { "debug" })
+                .env(
+                    "TRUNK_PROFILE",
+                    cfg.profile
+                        .as_deref()
+                        .unwrap_or_else(|| if cfg.release { "release" } else { "debug" }),
+                )
                 .env("TRUNK_HTML_FILE", &cfg.target)
                 .env("TRUNK_SOURCE_DIR", &cfg.target_parent)
                 .env("TRUNK_STAGING_DIR", &cfg.staging_dist)

--- a/src/pipelines/rust_app.rs
+++ b/src/pipelines/rust_app.rs
@@ -136,6 +136,10 @@ impl RustApp {
         if self.cfg.release {
             args.push("--release");
         }
+        if let Some(profile) = &self.cfg.profile {
+            args.push("--profile");
+            args.push(profile);
+        }
         if let Some(bin) = &self.bin {
             args.push("--bin");
             args.push(bin);
@@ -210,7 +214,11 @@ impl RustApp {
 
         // Ensure our output dir is in place.
         let wasm_bindgen_name = Application::WasmBindgen.name();
-        let mode_segment = if self.cfg.release { "release" } else { "debug" };
+        let mode_segment = self
+            .cfg
+            .profile
+            .as_deref()
+            .unwrap_or_else(|| if self.cfg.release { "release" } else { "debug" });
         let bindgen_out = self
             .manifest
             .metadata
@@ -273,7 +281,7 @@ impl RustApp {
     #[tracing::instrument(level = "trace", skip(self, hashed_name))]
     async fn wasm_opt_build(&self, hashed_name: &str) -> Result<()> {
         // If not in release mode, we skip calling wasm-opt.
-        if !self.cfg.release {
+        if !self.cfg.release && self.cfg.profile.is_none() {
             return Ok(());
         }
 
@@ -287,7 +295,11 @@ impl RustApp {
 
         // Ensure our output dir is in place.
         let wasm_opt_name = Application::WasmOpt.name();
-        let mode_segment = if self.cfg.release { "release" } else { "debug" };
+        let mode_segment = self
+            .cfg
+            .profile
+            .as_deref()
+            .unwrap_or_else(|| if self.cfg.release { "release" } else { "debug" });
         let output = self
             .manifest
             .metadata

--- a/src/pipelines/sass.rs
+++ b/src/pipelines/sass.rs
@@ -56,7 +56,11 @@ impl Sass {
         let sass = tools::get(Application::Sass, version).await?;
 
         // Compile the target SASS/SCSS file.
-        let style = if self.cfg.release { "compressed" } else { "expanded" };
+        let style = if self.cfg.profile.is_some() || self.cfg.release {
+            "compressed"
+        } else {
+            "expanded"
+        };
         let path_str = dunce::simplified(&self.asset.path).display().to_string();
         let file_name = format!("{}.css", &self.asset.file_stem.to_string_lossy());
         let file_path = dunce::simplified(&self.cfg.staging_dist.join(&file_name))


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [ ] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [ ] Updated `site` content with pertinent info (may not always apply).
- [ ] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.

## Reasoning

Rust recently (since 1.56) added support for [custom profiles](https://github.com/rust-lang/cargo/pull/9943/). This is especially convenient in a workspace where for example frontend and backend live together in the same repo as 2 crates of a workspace. 

If a crate is part of a workspace it can't define its own profile settings, thus there's only a single global `release` profile. But often you want different profile settings for server and frontend, the server optimized for speed, frontend for binary size. With this new feature, you can define a custom profile optimized for binary size and use it for the frontend only, while setting up the release profile for performance for every other crate.

## Description

This PR adds support for the cargo flag to Trunk, so you can configure which profile to use. Sadly, we have a few automatic settings that depend on the `release` flag and there is no proper solution when used with a profile.

These spots are:
- Decide whether to run `wasm-opt`.
- Decide to build CSS as `compressed` or `expanded`.

Currently, this is solved by treating a custom profile the same way as the `release` flag, but I'm sure that isn't what everyone wants. For example, if someone creates a custom profile for debug purposes, they surely don't want `wasm-opt` to be run.

### Improvements

To solve this issue, it would be best to change Trunk to follow the profile style. Something like:

Trunk.toml
```toml
# default debug profile
[profile.debug]
wasm-opt = 0
sass-style = "expanded"

# default release profile
[profile.release]
wasm-opt = 3
sass-style = "compressed"

# custom `minified` profile
[profile.minified]
wasm-opt = "z"
sass-style = "compressed"
```

These would be in sync with cargo's profiles, thus activating as follows:
- `trunk build` or `trunk build --profile debug` -> `debug`
- `trunk build --release` or `trunk build --profile release` -> `release`
- `trunk build --profile minified` -> `minified`

Also, for `wasm-opt` we can set the optimization level in the HTML file with `<link data-trunk rel="rust" data-wasm-opt="z">`. We might either remove it or keep it and decide what takes precedence. I would personally go with removing it to make the configuration easier and avoid mistakes and surprises. If we decide to keep it, it probably makes sense to choose the HTML setting over Trunk.toml?

### Further details

I didn't update the changelog and other docs yet, as I feel we have to discuss a bit further about the profiles, and just wanted to get a bit of input on this idea. I believe adding profiles to Trunk directly is very beneficial but would break current setups. Therefore, I didn't add it yet until we make further decisions.
