### PR TITLE
Serve on localhost by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 ### changed
 - Bump notify to 5.0.0-pre.13, which fixes [notify-rs/notify#356](https://github.com/notify-rs/notify/issues/356)
 - Remove the temporary output of the SASS compiler from the output directory of Trunk.
+- The `cargo serve` command now listens on `127.0.0.1` (localhost) instead of `0.0.0.0`, fixing security issues when on a public Wi-Fi or otherwise accessible network connection. The address can still be changed with the `Trunk.toml` or `--address` cli argument.
 
 ## 0.14.0
 ### added

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -18,7 +18,7 @@ ignore = []
 
 [serve]
 # The address to serve on.
-addr = "0.0.0.0"
+addr = "127.0.0.1"
 # The port to serve on.
 port = 8080
 # Open a browser tab once the initial build is complete.

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::net::IpAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -80,9 +81,9 @@ pub struct ConfigOptsWatch {
 /// Config options for the serve system.
 #[derive(Clone, Debug, Default, Deserialize, StructOpt)]
 pub struct ConfigOptsServe {
-    /// The address to serve on [default: 0.0.0.0]
+    /// The address to serve on [default: 127.0.0.1]
     #[structopt(long)]
-    pub address: Option<String>,
+    pub address: Option<IpAddr>,
     /// The port to serve on [default: 8080]
     #[structopt(long)]
     pub port: Option<u16>,

--- a/src/config/rt.rs
+++ b/src/config/rt.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -141,7 +142,7 @@ pub struct RtcServe {
     /// Runtime config for the watch system.
     pub watch: Arc<RtcWatch>,
     /// The IP address to serve on.
-    pub address: String,
+    pub address: IpAddr,
     /// The port to serve on.
     pub port: u16,
     /// Open a browser tab once the initial build is complete.
@@ -166,7 +167,7 @@ impl RtcServe {
         let watch = Arc::new(RtcWatch::new(build_opts, watch_opts, tools, hooks, !opts.no_autoreload)?);
         Ok(Self {
             watch,
-            address: opts.address.unwrap_or_else(|| "0.0.0.0".to_string()),
+            address: opts.address.unwrap_or(IpAddr::V4(Ipv4Addr::LOCALHOST)),
             port: opts.port.unwrap_or(8080),
             open: opts.open,
             proxy_backend: opts.proxy_backend,

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -95,7 +95,7 @@ impl ServeSystem {
             build_done_chan,
         ));
         let router = router(state, cfg.clone());
-        let addr = format!("{}:{}", cfg.address, cfg.port).parse()?;
+        let addr = (cfg.address, cfg.port).into();
         let server = Server::bind(&addr)
             .serve(router.into_make_service())
             .with_graceful_shutdown(shutdown_fut);


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [x] Updated README.md with pertinent info (may not always apply).
- [x] Updated `site` content with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.

Change the default listening interface from `0.0.0.0` to `127.0.0.1` (localhost). This was reported in #269 as a security issue, as listening on `0.0.0.0` makes the service accessible to everyone who can reach the device on the network. When working in a home network, it's not a big issue, but when in a public Wi-Fi this can be dangerous as it exposes the server to unknown people.

In addition, on macOS, it creates a system popup asking to allow network access to Trunk when binding to `0.0.0.0`. As a nice side effect, we avoid this message when listening on localhost only.

I took the freedom to change the address type from a `String` to an `IpAddr` as we parse it into a `SocketAddr` in the end, and a `SocketAddr` is just an `IpAddr` + port. This change allows to not misuse the address and be more specific about the data type. Luckily, **serde** and **clap** support deserializing `IpAddr` out of the box.

Fixes #269
