### PR TITLE
Fix new lints from Rust 1.58

### DIFF
--- a/src/config/models_test.rs
+++ b/src/config/models_test.rs
@@ -8,7 +8,7 @@ fn err_bad_trunk_toml_build_target() {
     let err = ConfigOpts::rtc_build(Default::default(), Some(path)).expect_err("expected config to err");
     let expected_err = format!(
         r#"error taking canonical path to [build].target "index.html" in "{}/tests/data/bad-build-target.toml""#,
-        cwd.to_string_lossy().to_string(),
+        cwd.to_string_lossy(),
     );
     assert_eq!(err.to_string(), expected_err);
 }
@@ -21,7 +21,7 @@ fn err_bad_trunk_toml_watch_path() {
     let err = ConfigOpts::rtc_watch(Default::default(), Default::default(), Some(path)).expect_err("expected config to err");
     let expected_err = format!(
         r#"error taking canonical path to [watch].watch "fake-dir" in "{}/tests/data/bad-watch-path.toml""#,
-        cwd.to_string_lossy().to_string(),
+        cwd.to_string_lossy(),
     );
     assert_eq!(err.to_string(), expected_err);
 }
@@ -34,7 +34,7 @@ fn err_bad_trunk_toml_watch_ignore() {
     let err = ConfigOpts::rtc_watch(Default::default(), Default::default(), Some(path)).expect_err("expected config to err");
     let expected_err = format!(
         r#"error taking canonical path to [watch].ignore "fake.html" in "{}/tests/data/bad-watch-ignore.toml""#,
-        cwd.to_string_lossy().to_string(),
+        cwd.to_string_lossy(),
     );
     assert_eq!(err.to_string(), expected_err);
 }

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -235,6 +235,7 @@ pub struct HashedFileOutput {
 /// A stage in the build process.
 ///
 /// This is used to specify when a hook will run.
+#[allow(clippy::enum_variant_names)]
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum PipelineStage {


### PR DESCRIPTION
Fix the new lints that came out with Rust 1.58.
This ensures that other PRs pass the `lint` step of the CI.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [x] Updated README.md with pertinent info (may not always apply).
- [x] Updated `site` content with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
