### PR TITLE
Switch from structopt to clap 3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,17 +216,32 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "12e8611f9ae4e068fa3e56931fded356ff745e70987ff76924a6e0ab1c8ef2e3"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "517358c28fcef6607bf6f76108e02afad7e82297d132a6b846dcc1fc3efcd153"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -436,7 +451,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c5f0096a91d210159eceb2ff5e1c4da18388a170e1e3ce948aac9c8fdbbf595"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro2",
  "quote",
  "syn",
@@ -688,6 +703,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -1171,6 +1192,15 @@ checksum = "176ee4b630d174d2da8241336763bb459281dddc0f4d87f72c3b1efc9a6109b7"
 dependencies = [
  "pathdiff",
  "winapi",
+]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1873,33 +1903,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -1955,6 +1961,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1966,12 +1981,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "thin-slice"
@@ -2241,6 +2253,7 @@ dependencies = [
  "bytes",
  "cargo-lock",
  "cargo_metadata",
+ "clap",
  "console",
  "directories-next",
  "dunce",
@@ -2257,8 +2270,6 @@ dependencies = [
  "reqwest",
  "seahash",
  "serde",
- "structopt",
- "structopt-derive",
  "tar",
  "tempfile",
  "tokio",
@@ -2413,12 +2424,6 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ axum = { version = "0.4", features = ["ws"] }
 bytes = "1"
 cargo-lock = "7"
 cargo_metadata = "0.14"
+clap = { version = "3.0.7", features = ["derive", "env"] }
 console = "0.15"
 directories-next = "2"
 dunce = "1"
@@ -38,8 +39,6 @@ remove_dir_all = "0.7"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "stream", "trust-dns"] }
 seahash = "4"
 serde = { version = "1", features = ["derive"] }
-structopt = "0.3"
-structopt-derive = "0.4"
 tar = "0.4"
 # See https://docs.rs/tokio/latest/tokio/#feature-flags - we basically use all of the features.
 tokio = { version = "1", default-features = false, features = ["full"] }

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -1,16 +1,16 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use structopt::StructOpt;
+use clap::Args;
 
 use crate::build::BuildSystem;
 use crate::config::{ConfigOpts, ConfigOptsBuild};
 
 /// Build the Rust WASM app and all of its assets.
-#[derive(Clone, Debug, StructOpt)]
-#[structopt(name = "build")]
+#[derive(Clone, Debug, Args)]
+#[clap(name = "build")]
 pub struct Build {
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub build: ConfigOptsBuild,
 }
 

--- a/src/cmd/clean.rs
+++ b/src/cmd/clean.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::process::Stdio;
 
 use anyhow::{ensure, Context, Result};
-use structopt::StructOpt;
+use clap::Args;
 use tokio::process::Command;
 
 use crate::common::remove_dir_all;
@@ -10,16 +10,16 @@ use crate::config::{ConfigOpts, ConfigOptsClean};
 use crate::tools::cache_dir;
 
 /// Clean output artifacts.
-#[derive(StructOpt)]
-#[structopt(name = "clean")]
+#[derive(Args)]
+#[clap(name = "clean")]
 pub struct Clean {
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub clean: ConfigOptsClean,
     /// Optionally clean any cached tools used by Trunk
     ///
     /// These tools are cached in a platform dependent "projects" dir. Removing them will cause
     /// them to be downloaded by Trunk next time they are needed.
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pub tools: bool,
 }
 

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -1,15 +1,15 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use structopt::StructOpt;
+use clap::{Args, Subcommand};
 
 use crate::config::ConfigOpts;
 
 /// Trunk config controls.
-#[derive(Clone, Debug, StructOpt)]
-#[structopt(name = "config")]
+#[derive(Clone, Debug, Args)]
+#[clap(name = "config")]
 pub struct Config {
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     action: ConfigSubcommands,
 }
 
@@ -29,7 +29,7 @@ impl Config {
     }
 }
 
-#[derive(Clone, Debug, StructOpt)]
+#[derive(Clone, Debug, Subcommand)]
 enum ConfigSubcommands {
     /// Show Trunk's current config pre-CLI.
     Show,

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -1,21 +1,21 @@
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use structopt::StructOpt;
+use clap::Args;
 use tokio::sync::broadcast;
 
 use crate::config::{ConfigOpts, ConfigOptsBuild, ConfigOptsServe, ConfigOptsWatch};
 use crate::serve::ServeSystem;
 
 /// Build, watch & serve the Rust WASM app and all of its assets.
-#[derive(StructOpt)]
-#[structopt(name = "serve")]
+#[derive(Args)]
+#[clap(name = "serve")]
 pub struct Serve {
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub build: ConfigOptsBuild,
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub watch: ConfigOptsWatch,
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub serve: ConfigOptsServe,
 }
 

--- a/src/cmd/watch.rs
+++ b/src/cmd/watch.rs
@@ -1,19 +1,19 @@
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use structopt::StructOpt;
+use clap::Args;
 use tokio::sync::broadcast;
 
 use crate::config::{ConfigOpts, ConfigOptsBuild, ConfigOptsWatch};
 use crate::watch::WatchSystem;
 
 /// Build & watch the Rust WASM app and all of its assets.
-#[derive(StructOpt)]
-#[structopt(name = "watch")]
+#[derive(Args)]
+#[clap(name = "watch")]
 pub struct Watch {
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub build: ConfigOptsBuild,
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub watch: ConfigOptsWatch,
 }
 

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -6,28 +6,28 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use axum::http::Uri;
+use clap::Args;
 use serde::{Deserialize, Deserializer};
-use structopt::StructOpt;
 
 use crate::common::parse_public_url;
 use crate::config::{RtcBuild, RtcClean, RtcServe, RtcWatch};
 use crate::pipelines::PipelineStage;
 
 /// Config options for the build system.
-#[derive(Clone, Debug, Default, Deserialize, StructOpt)]
+#[derive(Clone, Debug, Default, Deserialize, Args)]
 pub struct ConfigOptsBuild {
     /// The index HTML file to drive the bundling process [default: index.html]
-    #[structopt(parse(from_os_str))]
+    #[clap(parse(from_os_str))]
     pub target: Option<PathBuf>,
     /// Build in release mode [default: false]
-    #[structopt(long)]
+    #[clap(long)]
     #[serde(default)]
     pub release: bool,
     /// The output dir for all final assets [default: dist]
-    #[structopt(short, long, parse(from_os_str))]
+    #[clap(short, long, parse(from_os_str))]
     pub dist: Option<PathBuf>,
     /// The public URL from which assets are to be served [default: /]
-    #[structopt(long, parse(from_str=parse_public_url))]
+    #[clap(long, parse(from_str=parse_public_url))]
     pub public_url: Option<String>,
     /// Optional pattern for the app loader script [default: None]
     ///
@@ -36,7 +36,7 @@ pub struct ConfigOptsBuild {
     /// to key/value pairs provided in `pattern_params`.
     ///
     /// These values can only be provided via config file.
-    #[structopt(skip)]
+    #[clap(skip)]
     #[serde(default)]
     pub pattern_script: Option<String>,
     /// Optional pattern for the app preload element [default: None]
@@ -46,78 +46,78 @@ pub struct ConfigOptsBuild {
     /// to key/value pairs provided in `pattern_params`.
     ///
     /// These values can only be provided via config file.
-    #[structopt(skip)]
+    #[clap(skip)]
     #[serde(default)]
     pub pattern_preload: Option<String>,
-    #[structopt(skip)]
+    #[clap(skip)]
     #[serde(default)]
     /// Optional replacement parameters corresponding to the patterns provided in
     /// `pattern_script` and `pattern_preload`.
     ///
     /// When a pattern is being replaced with its corresponding value from this map, if the value is
     /// prefixed with the symbol `@`, then the value is expected to be a file path, and the pattern
-    /// will be replaced with the contents of the target file. This allows insertion of some big JSON
-    /// state or even HTML files as a part of the `index.html` build.
+    /// will be replaced with the contents of the target file. This allows insertion of some big
+    /// JSON state or even HTML files as a part of the `index.html` build.
     ///
-    /// Trunk will automatically insert the `base`, `wasm` and `js` key/values into this map. In order
-    //// for the app to be loaded properly, the patterns `{base}`, `{wasm}` and `{js}` should be used
-    /// in `pattern_script` and `pattern_preload`.
+    /// Trunk will automatically insert the `base`, `wasm` and `js` key/values into this map. In
+    /// order for the app to be loaded properly, the patterns `{base}`, `{wasm}` and `{js}` should
+    /// be used in `pattern_script` and `pattern_preload`.
     ///
     /// These values can only be provided via config file.
     pub pattern_params: Option<HashMap<String, String>>,
 }
 
 /// Config options for the watch system.
-#[derive(Clone, Debug, Default, Deserialize, StructOpt)]
+#[derive(Clone, Debug, Default, Deserialize, Args)]
 pub struct ConfigOptsWatch {
     /// Watch specific file(s) or folder(s) [default: build target parent folder]
-    #[structopt(short, long, parse(from_os_str), value_name = "path")]
+    #[clap(short, long, parse(from_os_str), value_name = "path")]
     pub watch: Option<Vec<PathBuf>>,
     /// Paths to ignore [default: []]
-    #[structopt(short, long, parse(from_os_str), value_name = "path")]
+    #[clap(short, long, parse(from_os_str), value_name = "path")]
     pub ignore: Option<Vec<PathBuf>>,
 }
 
 /// Config options for the serve system.
-#[derive(Clone, Debug, Default, Deserialize, StructOpt)]
+#[derive(Clone, Debug, Default, Deserialize, Args)]
 pub struct ConfigOptsServe {
     /// The address to serve on [default: 127.0.0.1]
-    #[structopt(long)]
+    #[clap(long)]
     pub address: Option<IpAddr>,
     /// The port to serve on [default: 8080]
-    #[structopt(long)]
+    #[clap(long)]
     pub port: Option<u16>,
     /// Open a browser tab once the initial build is complete [default: false]
-    #[structopt(long)]
+    #[clap(long)]
     #[serde(default)]
     pub open: bool,
     /// A URL to which requests will be proxied [default: None]
-    #[structopt(long = "proxy-backend")]
+    #[clap(long = "proxy-backend")]
     #[serde(default, deserialize_with = "deserialize_uri")]
     pub proxy_backend: Option<Uri>,
     /// The URI on which to accept requests which are to be rewritten and proxied to backend
     /// [default: None]
-    #[structopt(long = "proxy-rewrite")]
+    #[clap(long = "proxy-rewrite")]
     #[serde(default)]
     pub proxy_rewrite: Option<String>,
     /// Configure the proxy for handling WebSockets [default: false]
-    #[structopt(long = "proxy-ws")]
+    #[clap(long = "proxy-ws")]
     #[serde(default)]
     pub proxy_ws: bool,
     /// Disable auto-reload of the web app [default: false]
-    #[structopt(long = "no-autoreload")]
+    #[clap(long = "no-autoreload")]
     #[serde(default)]
     pub no_autoreload: bool,
 }
 
 /// Config options for the serve system.
-#[derive(Clone, Debug, Default, Deserialize, StructOpt)]
+#[derive(Clone, Debug, Default, Deserialize, Args)]
 pub struct ConfigOptsClean {
     /// The output dir for all final assets [default: dist]
-    #[structopt(short, long, parse(from_os_str))]
+    #[clap(short, long, parse(from_os_str))]
     pub dist: Option<PathBuf>,
     /// Optionally perform a cargo clean [default: false]
-    #[structopt(long)]
+    #[clap(long)]
     #[serde(default)]
     pub cargo: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,12 +14,12 @@ mod watch;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use structopt::StructOpt;
+use clap::{Parser, Subcommand};
 use tracing_subscriber::prelude::*;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let cli = Trunk::from_args();
+    let cli = Trunk::parse();
 
     #[cfg(windows)]
     if let Err(err) = ansi_term::enable_ansi_support() {
@@ -46,16 +46,16 @@ async fn main() -> Result<()> {
 }
 
 /// Build, bundle & ship your Rust WASM application to the web.
-#[derive(StructOpt)]
-#[structopt(name = "trunk")]
+#[derive(Parser)]
+#[clap(about, author, version, name = "trunk")]
 struct Trunk {
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     action: TrunkSubcommands,
     /// Path to the Trunk config file [default: Trunk.toml]
-    #[structopt(long, parse(from_os_str), env = "TRUNK_CONFIG")]
+    #[clap(long, parse(from_os_str), env = "TRUNK_CONFIG")]
     pub config: Option<PathBuf>,
     /// Enable verbose logging.
-    #[structopt(short)]
+    #[clap(short)]
     pub v: bool,
 }
 
@@ -72,7 +72,7 @@ impl Trunk {
     }
 }
 
-#[derive(StructOpt)]
+#[derive(Subcommand)]
 enum TrunkSubcommands {
     /// Build the Rust WASM app and all of its assets.
     Build(cmd::build::Build),


### PR DESCRIPTION
Switching from `structopt` to `clap` 3.0 as structop was integrated into the latest clap release.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [ ] Updated CHANGELOG.md describing pertinent changes.
- [x] Updated README.md with pertinent info (may not always apply).
- [x] Updated `site` content with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
