### PR TITLE
Document changed behavior of path delimiter handling on Windows 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 - Bump notify to 5.0.0-pre.13, which fixes [notify-rs/notify#356](https://github.com/notify-rs/notify/issues/356)
 - Remove the temporary output of the SASS compiler from the output directory of Trunk.
 - The `cargo serve` command now listens on `127.0.0.1` (localhost) instead of `0.0.0.0`, fixing security issues when on a public Wi-Fi or otherwise accessible network connection. The address can still be changed with the `Trunk.toml` or `--address` cli argument.
+- Force HTTP/1 on proxy client, which fixes [#280](https://github.com/thedodd/trunk/issues/280)
 
 ## 0.14.0
 ### added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 ### added
 - Added the `--address` option for `trunk serve`.
 - Open autoreload websocket using wss when assets are served over a secure connection.
+- Path delimiter handling in Trunk.toml is now consistent with `std::path`,
+"/" now can be used as path delimiters on Windows.
 
 ### changed
 - Bump notify to 5.0.0-pre.13, which fixes [notify-rs/notify#356](https://github.com/notify-rs/notify/issues/356)

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -83,6 +83,7 @@ impl ServeSystem {
 
         // Build the proxy client.
         let client = reqwest::ClientBuilder::new()
+            .http1_only()
             .build()
             .context("error building proxy client")?;
 


### PR DESCRIPTION
#89 is silently implemented in some commits between 0.14 and master, this PR documents the behavior change.

**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [/] Updated README.md with pertinent info (may not always apply). (std::path-consistent delimiter handling should be what rustaceans expect by default)
- [/] Updated `site` content with pertinent info (may not always apply). (same)
- [ ] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓. **pls squash on merge, thanks**
