### PR TITLE
Add asset processing for `script` tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 dist
 site/public/*
 .vscode
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 ## Unreleased
 ### added
+- Allow processing `<script>` tags with the asset pipeline
 ### changed
 ### fixed
 

--- a/examples/vanilla/index.html
+++ b/examples/vanilla/index.html
@@ -11,5 +11,7 @@
 </head>
 <body>
     <link data-trunk rel="rust" href="Cargo.toml" data-wasm-opt="z" data-bin="vanilla-example"/>
+    <script data-trunk src="src/script.js"></script>
 </body>
+<script>testFromJavaScript();</script>
 </html>

--- a/examples/vanilla/src/script.js
+++ b/examples/vanilla/src/script.js
@@ -1,0 +1,3 @@
+function testFromJavaScript() {
+    console.log("Hello from JavaScript");
+}

--- a/site/content/assets.md
+++ b/site/content/assets.md
@@ -4,14 +4,18 @@ description = "Assets"
 weight = 1
 +++
 
-Declaring assets to be processed by Trunk is simple and extensible. All assets to be processed by Trunk must follow these three rules:
+Declaring assets to be processed by Trunk is simple and extensible.
+
+Trunk is still a young project, and new asset types will be added as we move forward. Keep an eye on [trunk#3](https://github.com/thedodd/trunk/issues/3) for more information on planned asset types, implementation status, and please contribute to the discussion if you think something is missing.
+
+# Link Asset Types
+All link assets to be processed by Trunk must follow these three rules:
 - Must be declared as a valid HTML `link` tag.
 - Must have the attribute `data-trunk`.
 - Must have the attribute `rel="{type}"`, where `{type}` is one of the asset types listed below.
 
 This will typically look like: `<link data-trunk rel="{type}" href="{path}" ..other options here.. />`. Each asset type described below specifies the required and optional attributes for its asset type. All `<link data-trunk .../>` HTML elements will be replaced with the output HTML of the associated pipeline.
 
-# Asset Types
 ## rust
 ✅ `rel="rust"`: Trunk will compile the specified Cargo project as WASM and load it. This is optional. If not specified, Trunk will look for a `Cargo.toml` in the parent directory of the source HTML file.
   - `href`: (optional) the path to the `Cargo.toml` of the Rust project. If a directory is specified, then Trunk will look for the `Cargo.toml` in the given directory. If no value is specified, then Trunk will look for a `Cargo.toml` in the parent directory of the source HTML file.
@@ -50,9 +54,20 @@ This will typically look like: `<link data-trunk rel="{type}" href="{path}" ..ot
 ## copy-dir
 ✅ `rel="copy-dir"`: Trunk will recursively copy the directory specified in the `href` attribute to the `dist` dir. This content is copied exactly, no hashing is performed.
 
-Trunk is still a young project, and new asset types will be added as we move forward. Keep an eye on [trunk#3](https://github.com/thedodd/trunk/issues/3) for more information on planned asset types, implementation status, and please contribute to the discussion if you think something is missing.
+# Script Asset Types
+Script assets are bit more diverse.
 
-# JS Snippets
+## Script Assets
+Classic script assets processed by Trunk must follow these three rules:
+- Must be declared as a valid HTML `script` tag.
+- Must have the attribute `data-trunk`.
+- Must have the attribute `src`, pointing to a script file
+
+This will typically look like: `<script data-trunk src="{path}" ..other options here.. />`. All `<script data-trunk .../>` HTML elements will be replaced with the output HTML of the associated pipeline.
+
+Trunk will copy script files found in the source HTML without content modification. This content is hashed for cache control. The `src` attribute must be included in the script pointing to the script file to be processed.
+
+## JS Snippets
 JS snippets generated from the [wasm-bindgen JS snippets feature](https://rustwasm.github.io/docs/wasm-bindgen/reference/js-snippets.html) are automatically copied to the dist dir, hashed and ready to rock. No additional setup is required. Just use the feature in your application, and Trunk will take care of the rest.
 
 # Images & Other Resources

--- a/src/pipelines/copy_dir.rs
+++ b/src/pipelines/copy_dir.rs
@@ -8,7 +8,7 @@ use nipper::Document;
 use tokio::fs;
 use tokio::task::JoinHandle;
 
-use super::{LinkAttrs, TrunkLinkPipelineOutput, ATTR_HREF};
+use super::{LinkAttrs, TrunkAssetPipelineOutput, ATTR_HREF};
 use crate::common::copy_dir_recursive;
 use crate::config::RtcBuild;
 
@@ -45,13 +45,13 @@ impl CopyDir {
 
     /// Spawn the pipeline for this asset type.
     #[tracing::instrument(level = "trace", skip(self))]
-    pub fn spawn(self) -> JoinHandle<Result<TrunkLinkPipelineOutput>> {
+    pub fn spawn(self) -> JoinHandle<Result<TrunkAssetPipelineOutput>> {
         tokio::spawn(self.run())
     }
 
     /// Run this pipeline.
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn run(self) -> Result<TrunkLinkPipelineOutput> {
+    async fn run(self) -> Result<TrunkAssetPipelineOutput> {
         let rel_path = crate::common::strip_prefix(&self.path);
         tracing::info!(path = ?rel_path, "copying directory");
 
@@ -65,7 +65,7 @@ impl CopyDir {
         copy_dir_recursive(canonical_path, dir_out).await?;
 
         tracing::info!(path = ?rel_path, "finished copying directory");
-        Ok(TrunkLinkPipelineOutput::CopyDir(CopyDirOutput(self.id)))
+        Ok(TrunkAssetPipelineOutput::CopyDir(CopyDirOutput(self.id)))
     }
 }
 

--- a/src/pipelines/copy_file.rs
+++ b/src/pipelines/copy_file.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result};
 use nipper::Document;
 use tokio::task::JoinHandle;
 
-use super::{AssetFile, LinkAttrs, TrunkLinkPipelineOutput, ATTR_HREF};
+use super::{AssetFile, LinkAttrs, TrunkAssetPipelineOutput, ATTR_HREF};
 use crate::config::RtcBuild;
 
 /// A CopyFile asset pipeline.
@@ -41,18 +41,18 @@ impl CopyFile {
 
     /// Spawn the pipeline for this asset type.
     #[tracing::instrument(level = "trace", skip(self))]
-    pub fn spawn(self) -> JoinHandle<Result<TrunkLinkPipelineOutput>> {
+    pub fn spawn(self) -> JoinHandle<Result<TrunkAssetPipelineOutput>> {
         tokio::spawn(self.run())
     }
 
     /// Run this pipeline.
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn run(self) -> Result<TrunkLinkPipelineOutput> {
+    async fn run(self) -> Result<TrunkAssetPipelineOutput> {
         let rel_path = crate::common::strip_prefix(&self.asset.path);
         tracing::info!(path = ?rel_path, "copying file");
         let _ = self.asset.copy(&self.cfg.staging_dist, false).await?;
         tracing::info!(path = ?rel_path, "finished copying file");
-        Ok(TrunkLinkPipelineOutput::CopyFile(CopyFileOutput(self.id)))
+        Ok(TrunkAssetPipelineOutput::CopyFile(CopyFileOutput(self.id)))
     }
 }
 

--- a/src/pipelines/icon.rs
+++ b/src/pipelines/icon.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result};
 use nipper::Document;
 use tokio::task::JoinHandle;
 
-use super::{AssetFile, LinkAttrs, TrunkLinkPipelineOutput, ATTR_HREF};
+use super::{AssetFile, LinkAttrs, TrunkAssetPipelineOutput, ATTR_HREF};
 use crate::config::RtcBuild;
 
 /// An Icon asset pipeline.
@@ -41,13 +41,13 @@ impl Icon {
 
     /// Spawn the pipeline for this asset type.
     #[tracing::instrument(level = "trace", skip(self))]
-    pub fn spawn(self) -> JoinHandle<Result<TrunkLinkPipelineOutput>> {
+    pub fn spawn(self) -> JoinHandle<Result<TrunkAssetPipelineOutput>> {
         tokio::spawn(self.run())
     }
 
     /// Run this pipeline.
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn run(self) -> Result<TrunkLinkPipelineOutput> {
+    async fn run(self) -> Result<TrunkAssetPipelineOutput> {
         let rel_path = crate::common::strip_prefix(&self.asset.path);
         tracing::info!(path = ?rel_path, "copying & hashing icon");
         let file = self
@@ -55,7 +55,7 @@ impl Icon {
             .copy(&self.cfg.staging_dist, self.cfg.filehash)
             .await?;
         tracing::info!(path = ?rel_path, "finished copying & hashing icon");
-        Ok(TrunkLinkPipelineOutput::Icon(IconOutput {
+        Ok(TrunkAssetPipelineOutput::Icon(IconOutput {
             cfg: self.cfg.clone(),
             id: self.id,
             file,

--- a/src/pipelines/inline.rs
+++ b/src/pipelines/inline.rs
@@ -8,7 +8,7 @@ use anyhow::{bail, Context, Result};
 use nipper::Document;
 use tokio::task::JoinHandle;
 
-use super::{AssetFile, LinkAttrs, TrunkLinkPipelineOutput, ATTR_HREF, ATTR_TYPE};
+use super::{AssetFile, LinkAttrs, TrunkAssetPipelineOutput, ATTR_HREF, ATTR_TYPE};
 
 /// An Inline asset pipeline.
 pub struct Inline {
@@ -45,19 +45,19 @@ impl Inline {
 
     /// Spawn the pipeline for this asset type.
     #[tracing::instrument(level = "trace", skip(self))]
-    pub fn spawn(self) -> JoinHandle<Result<TrunkLinkPipelineOutput>> {
+    pub fn spawn(self) -> JoinHandle<Result<TrunkAssetPipelineOutput>> {
         tokio::spawn(self.run())
     }
 
     /// Run this pipeline.
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn run(self) -> Result<TrunkLinkPipelineOutput> {
+    async fn run(self) -> Result<TrunkAssetPipelineOutput> {
         let rel_path = crate::common::strip_prefix(&self.asset.path);
         tracing::info!(path = ?rel_path, "reading file content");
         let content = self.asset.read_to_string().await?;
         tracing::info!(path = ?rel_path, "finished reading file content");
 
-        Ok(TrunkLinkPipelineOutput::Inline(InlineOutput {
+        Ok(TrunkAssetPipelineOutput::Inline(InlineOutput {
             id: self.id,
             content,
             content_type: self.content_type,

--- a/src/pipelines/js.rs
+++ b/src/pipelines/js.rs
@@ -1,4 +1,4 @@
-//! CSS asset pipeline.
+//! JS asset pipeline.
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -7,11 +7,11 @@ use anyhow::{Context, Result};
 use nipper::Document;
 use tokio::task::JoinHandle;
 
-use super::{AssetFile, LinkAttrs, TrunkAssetPipelineOutput, ATTR_HREF};
+use super::{AssetFile, TrunkAssetPipelineOutput};
 use crate::config::RtcBuild;
 
-/// A CSS asset pipeline.
-pub struct Css {
+/// A JS asset pipeline.
+pub struct Js {
     /// The ID of this pipeline's source HTML element.
     id: usize,
     /// Runtime build config.
@@ -20,21 +20,18 @@ pub struct Css {
     asset: AssetFile,
 }
 
-impl Css {
-    pub const TYPE_CSS: &'static str = "css";
-
+impl Js {
     pub async fn new(
         cfg: Arc<RtcBuild>,
         html_dir: Arc<PathBuf>,
-        attrs: LinkAttrs,
+        src: Option<String>,
         id: usize,
     ) -> Result<Self> {
         // Build the path to the target asset.
-        let href_attr = attrs.get(ATTR_HREF).context(
-            r#"required attr `href` missing for <link data-trunk rel="css" .../> element"#,
-        )?;
+        let src_attr =
+            src.context(r#"required attr `src` missing for <script data-trunk .../> element"#)?;
         let mut path = PathBuf::new();
-        path.extend(href_attr.split('/'));
+        path.extend(src_attr.split('/'));
         let asset = AssetFile::new(&html_dir, path).await?;
         Ok(Self { id, cfg, asset })
     }
@@ -49,13 +46,13 @@ impl Css {
     #[tracing::instrument(level = "trace", skip(self))]
     async fn run(self) -> Result<TrunkAssetPipelineOutput> {
         let rel_path = crate::common::strip_prefix(&self.asset.path);
-        tracing::info!(path = ?rel_path, "copying & hashing css");
+        tracing::info!(path = ?rel_path, "copying & hashing js");
         let file = self
             .asset
             .copy(&self.cfg.staging_dist, self.cfg.filehash)
             .await?;
-        tracing::info!(path = ?rel_path, "finished copying & hashing css");
-        Ok(TrunkAssetPipelineOutput::Css(CssOutput {
+        tracing::info!(path = ?rel_path, "finished copying & hashing js");
+        Ok(TrunkAssetPipelineOutput::Js(JsOutput {
             cfg: self.cfg.clone(),
             id: self.id,
             file,
@@ -63,21 +60,21 @@ impl Css {
     }
 }
 
-/// The output of a CSS build pipeline.
-pub struct CssOutput {
+/// The output of a JS build pipeline.
+pub struct JsOutput {
     /// The runtime build config.
     pub cfg: Arc<RtcBuild>,
     /// The ID of this pipeline.
     pub id: usize,
-    /// Name the finalized output file.
+    /// Name of the finalized output file.
     pub file: String,
 }
 
-impl CssOutput {
+impl JsOutput {
     pub async fn finalize(self, dom: &mut Document) -> Result<()> {
-        dom.select(&super::trunk_id_selector(self.id))
+        dom.select(&super::trunk_script_id_selector(self.id))
             .replace_with_html(format!(
-                r#"<link rel="stylesheet" href="{base}{file}"/>"#,
+                r#"<script src="{base}{file}"/>"#,
                 base = &self.cfg.public_url,
                 file = self.file
             ));

--- a/src/pipelines/rust.rs
+++ b/src/pipelines/rust.rs
@@ -15,7 +15,7 @@ use tokio::process::Command;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
-use super::{LinkAttrs, TrunkLinkPipelineOutput, ATTR_HREF, SNIPPETS_DIR};
+use super::{LinkAttrs, TrunkAssetPipelineOutput, ATTR_HREF, SNIPPETS_DIR};
 use crate::common::{self, copy_dir_recursive, path_exists};
 use crate::config::{CargoMetadata, ConfigOptsTools, Features, RtcBuild};
 use crate::tools::{self, Application};
@@ -197,16 +197,16 @@ impl RustApp {
 
     /// Spawn a new pipeline.
     #[tracing::instrument(level = "trace", skip(self))]
-    pub fn spawn(self) -> JoinHandle<Result<TrunkLinkPipelineOutput>> {
+    pub fn spawn(self) -> JoinHandle<Result<TrunkAssetPipelineOutput>> {
         tokio::spawn(self.build())
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn build(mut self) -> Result<TrunkLinkPipelineOutput> {
+    async fn build(mut self) -> Result<TrunkAssetPipelineOutput> {
         let (wasm, hashed_name) = self.cargo_build().await?;
         let output = self.wasm_bindgen_build(wasm.as_ref(), &hashed_name).await?;
         self.wasm_opt_build(&output.wasm_output).await?;
-        Ok(TrunkLinkPipelineOutput::RustApp(output))
+        Ok(TrunkAssetPipelineOutput::RustApp(output))
     }
 
     #[tracing::instrument(level = "trace", skip(self))]

--- a/src/pipelines/sass.rs
+++ b/src/pipelines/sass.rs
@@ -8,7 +8,7 @@ use nipper::Document;
 use tokio::fs;
 use tokio::task::JoinHandle;
 
-use super::{AssetFile, LinkAttrs, TrunkLinkPipelineOutput, ATTR_HREF, ATTR_INLINE};
+use super::{AssetFile, LinkAttrs, TrunkAssetPipelineOutput, ATTR_HREF, ATTR_INLINE};
 use crate::common;
 use crate::config::RtcBuild;
 use crate::tools::{self, Application};
@@ -53,13 +53,13 @@ impl Sass {
 
     /// Spawn the pipeline for this asset type.
     #[tracing::instrument(level = "trace", skip(self))]
-    pub fn spawn(self) -> JoinHandle<Result<TrunkLinkPipelineOutput>> {
+    pub fn spawn(self) -> JoinHandle<Result<TrunkAssetPipelineOutput>> {
         tokio::spawn(self.run())
     }
 
     /// Run this pipeline.
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn run(self) -> Result<TrunkLinkPipelineOutput> {
+    async fn run(self) -> Result<TrunkAssetPipelineOutput> {
         // tracing::info!("downloading sass");
         let version = self.cfg.tools.sass.as_deref();
         let sass = tools::get(Application::Sass, version).await?;
@@ -109,7 +109,7 @@ impl Sass {
         };
 
         tracing::info!(path = ?rel_path, "finished compiling sass/scss");
-        Ok(TrunkLinkPipelineOutput::Sass(SassOutput {
+        Ok(TrunkAssetPipelineOutput::Sass(SassOutput {
             cfg: self.cfg.clone(),
             id: self.id,
             css_ref,


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [X] Updated `site` content with pertinent info (may not always apply).
- [ ] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.

This change adds support for processing `<script>` tags with the asset pipeline in a way similar to `<link rel="css">` assets. This fixes the request originally posted by @hobofan in https://github.com/thedodd/trunk/issues/3#issuecomment-698849526