### PR TITLE
Reduce amount of custom rustfmt settings

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,27 +1,9 @@
-unstable_features = true
-edition = "2018"
-
 comment_width = 100
-fn_args_layout = "Compressed"
-max_width = 150
-use_small_heuristics = "Default"
-use_try_shorthand = true
-
-# pre-unstable
-chain_width = 75
-single_line_if_else_max_width = 75
-space_around_attr_eq = false
-struct_lit_width = 50
-
-# unstable
 condense_wildcard_suffixes = true
 format_code_in_doc_comments = true
 format_strings = true
-match_block_trailing_comma = false
-normalize_comments = true
-normalize_doc_attributes = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"
 reorder_impl_items = true
-struct_lit_single_line = true
-trailing_comma = "Vertical"
 use_field_init_shorthand = true
 wrap_comments = true

--- a/src/build.rs
+++ b/src/build.rs
@@ -31,7 +31,10 @@ impl BuildSystem {
     ///
     /// Reducing the number of assumptions here should help us to stay flexible when adding new
     /// commands, refactoring and the like.
-    pub async fn new(cfg: Arc<RtcBuild>, ignore_chan: Option<mpsc::Sender<PathBuf>>) -> Result<Self> {
+    pub async fn new(
+        cfg: Arc<RtcBuild>,
+        ignore_chan: Option<mpsc::Sender<PathBuf>>,
+    ) -> Result<Self> {
         let html_pipeline = Arc::new(HtmlPipeline::new(cfg.clone(), ignore_chan)?);
         Ok(Self { cfg, html_pipeline })
     }
@@ -74,7 +77,9 @@ impl BuildSystem {
             .context("error from HTML pipeline")?;
 
         // Move distribution from staging dist to final dist
-        self.finalize_dist().await.context("error applying built distribution")?;
+        self.finalize_dist()
+            .await
+            .context("error applying built distribution")?;
         Ok(())
     }
 
@@ -127,7 +132,9 @@ impl BuildSystem {
 
             fs::rename(entry.path(), &target_path)
                 .await
-                .with_context(|| format!("error moving {:?} to {:?}", &entry.path(), &target_path))?;
+                .with_context(|| {
+                    format!("error moving {:?} to {:?}", &entry.path(), &target_path)
+                })?;
         }
         Ok(())
     }
@@ -151,9 +158,13 @@ impl BuildSystem {
                 .await
                 .context("error reading metadata of file in final dist dir")?;
             if file_type.is_dir() {
-                remove_dir_all(entry.path()).await.context("error cleaning final dist")?;
+                remove_dir_all(entry.path())
+                    .await
+                    .context("error cleaning final dist")?;
             } else if file_type.is_symlink() || file_type.is_file() {
-                fs::remove_file(entry.path()).await.context("error cleaning final dist")?;
+                fs::remove_file(entry.path())
+                    .await
+                    .context("error cleaning final dist")?;
             }
         }
         Ok(())

--- a/src/cmd/clean.rs
+++ b/src/cmd/clean.rs
@@ -36,7 +36,11 @@ impl Clean {
                 .stderr(Stdio::piped())
                 .output()
                 .await?;
-            ensure!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+            ensure!(
+                output.status.success(),
+                "{}",
+                String::from_utf8_lossy(&output.stderr)
+            );
         }
         if self.tools {
             tracing::debug!("cleaning trunk tools cache dir");

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -27,11 +27,15 @@ impl Serve {
         let system = ServeSystem::new(cfg, shutdown_tx.clone()).await?;
 
         let system_handle = tokio::spawn(system.run());
-        let _res = tokio::signal::ctrl_c().await.context("error awaiting shutdown signal")?;
+        tokio::signal::ctrl_c()
+            .await
+            .context("error awaiting shutdown signal")?;
         tracing::debug!("received shutdown signal");
-        let _res = shutdown_tx.send(());
+        shutdown_tx.send(()).ok();
         drop(shutdown_tx); // Ensure other components see the drop to avoid race conditions.
-        system_handle.await.context("error awaiting system shutdown")??;
+        system_handle
+            .await
+            .context("error awaiting system shutdown")??;
 
         Ok(())
     }

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,24 +1,25 @@
 //! Common functionality and types.
 
+use std::ffi::OsStr;
 use std::fmt::Debug;
 use std::fs::Metadata;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::{ffi::OsStr, io::ErrorKind};
 
 use anyhow::{anyhow, bail, Context, Result};
+use console::Emoji;
 use once_cell::sync::Lazy;
 use tokio::fs;
 use tokio::process::Command;
-
-use console::Emoji;
 
 pub static BUILDING: Emoji<'_, '_> = Emoji("📦", "");
 pub static SUCCESS: Emoji<'_, '_> = Emoji("✅", "");
 pub static ERROR: Emoji<'_, '_> = Emoji("❌", "");
 pub static SERVER: Emoji<'_, '_> = Emoji("📡", "");
 
-static CWD: Lazy<PathBuf> = Lazy::new(|| std::env::current_dir().expect("error getting current dir"));
+static CWD: Lazy<PathBuf> =
+    Lazy::new(|| std::env::current_dir().expect("error getting current dir"));
 
 /// Ensure the given value for `--public-url` is formatted correctly.
 pub fn parse_public_url(val: &str) -> String {
@@ -34,7 +35,10 @@ where
     T: AsRef<Path> + Send + 'static,
 {
     if !path_exists(&from_dir).await? {
-        return Err(anyhow!("directory can not be copied as it does not exist {:?}", &from_dir));
+        return Err(anyhow!(
+            "directory can not be copied as it does not exist {:?}",
+            &from_dir
+        ));
     }
 
     tokio::task::spawn_blocking(move || -> Result<()> {
@@ -72,8 +76,19 @@ pub async fn path_exists(path: impl AsRef<Path>) -> Result<bool> {
     fs::metadata(path.as_ref())
         .await
         .map(|_| true)
-        .or_else(|error| if error.kind() == ErrorKind::NotFound { Ok(false) } else { Err(error) })
-        .with_context(|| format!("error checking for existance of path at {:?}", path.as_ref()))
+        .or_else(|error| {
+            if error.kind() == ErrorKind::NotFound {
+                Ok(false)
+            } else {
+                Err(error)
+            }
+        })
+        .with_context(|| {
+            format!(
+                "error checking for existance of path at {:?}",
+                path.as_ref()
+            )
+        })
 }
 
 /// Check whether a given path exists, is a file and marked as executable.
@@ -89,7 +104,13 @@ pub async fn is_executable(path: impl AsRef<Path>) -> Result<bool> {
     fs::metadata(path.as_ref())
         .await
         .map(|meta| meta.is_file() && has_executable_flag(meta))
-        .or_else(|error| if error.kind() == ErrorKind::NotFound { Ok(false) } else { Err(error) })
+        .or_else(|error| {
+            if error.kind() == ErrorKind::NotFound {
+                Ok(false)
+            } else {
+                Err(error)
+            }
+        })
         .with_context(|| format!("error checking file mode for file {:?}", path.as_ref()))
 }
 

--- a/src/config/manifest.rs
+++ b/src/config/manifest.rs
@@ -33,6 +33,10 @@ impl CargoMetadata {
         // Get the path to the Cargo.toml manifest.
         let manifest_path = package.manifest_path.to_string();
 
-        Ok(Self { metadata, package, manifest_path })
+        Ok(Self {
+            metadata,
+            package,
+            manifest_path,
+        })
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -17,5 +17,8 @@ pub const DIST_DIR: &str = "dist";
 pub const STAGE_DIR: &str = ".stage";
 
 pub use manifest::CargoMetadata;
-pub use models::{ConfigOpts, ConfigOptsBuild, ConfigOptsClean, ConfigOptsHook, ConfigOptsProxy, ConfigOptsServe, ConfigOptsTools, ConfigOptsWatch};
+pub use models::{
+    ConfigOpts, ConfigOptsBuild, ConfigOptsClean, ConfigOptsHook, ConfigOptsProxy, ConfigOptsServe,
+    ConfigOptsTools, ConfigOptsWatch,
+};
 pub use rt::{RtcBuild, RtcClean, RtcServe, RtcWatch};

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -54,10 +54,10 @@ pub struct ConfigOptsBuild {
     /// Optional replacement parameters corresponding to the patterns provided in
     /// `pattern_script` and `pattern_preload`.
     ///
-    /// When a pattern is being replaced with its corresponding value from this map, if the value is
-    /// prefixed with the symbol `@`, then the value is expected to be a file path, and the pattern
-    /// will be replaced with the contents of the target file. This allows insertion of some big
-    /// JSON state or even HTML files as a part of the `index.html` build.
+    /// When a pattern is being replaced with its corresponding value from this map, if the value
+    /// is prefixed with the symbol `@`, then the value is expected to be a file path, and the
+    /// pattern will be replaced with the contents of the target file. This allows insertion of
+    /// some big JSON state or even HTML files as a part of the `index.html` build.
     ///
     /// Trunk will automatically insert the `base`, `wasm` and `js` key/values into this map. In
     /// order for the app to be loaded properly, the patterns `{base}`, `{wasm}` and `{js}` should
@@ -146,8 +146,8 @@ pub struct ConfigOptsProxy {
     /// An optional URI prefix which is to be used as the base URI for proxying requests, which
     /// defaults to the URI of the backend.
     ///
-    /// When a value is specified, requests received on this URI will have this URI segment replaced
-    /// with the URI of the `backend`.
+    /// When a value is specified, requests received on this URI will have this URI segment
+    /// replaced with the URI of the `backend`.
     pub rewrite: Option<String>,
     /// Configure the proxy for handling WebSockets.
     #[serde(default)]
@@ -199,11 +199,17 @@ impl ConfigOpts {
         let build_opts = build_layer.build.unwrap_or_default();
         let tools_opts = build_layer.tools.unwrap_or_default();
         let hooks_opts = build_layer.hooks.unwrap_or_default();
-        Ok(Arc::new(RtcBuild::new(build_opts, tools_opts, hooks_opts, false)?))
+        Ok(Arc::new(RtcBuild::new(
+            build_opts, tools_opts, hooks_opts, false,
+        )?))
     }
 
     /// Extract the runtime config for the watch system based on all config layers.
-    pub fn rtc_watch(cli_build: ConfigOptsBuild, cli_watch: ConfigOptsWatch, config: Option<PathBuf>) -> Result<Arc<RtcWatch>> {
+    pub fn rtc_watch(
+        cli_build: ConfigOptsBuild,
+        cli_watch: ConfigOptsWatch,
+        config: Option<PathBuf>,
+    ) -> Result<Arc<RtcWatch>> {
         let base_layer = Self::file_and_env_layers(config)?;
         let build_layer = Self::cli_opts_layer_build(cli_build, base_layer);
         let watch_layer = Self::cli_opts_layer_watch(cli_watch, build_layer);
@@ -211,12 +217,17 @@ impl ConfigOpts {
         let watch_opts = watch_layer.watch.unwrap_or_default();
         let tools_opts = watch_layer.tools.unwrap_or_default();
         let hooks_opts = watch_layer.hooks.unwrap_or_default();
-        Ok(Arc::new(RtcWatch::new(build_opts, watch_opts, tools_opts, hooks_opts, false)?))
+        Ok(Arc::new(RtcWatch::new(
+            build_opts, watch_opts, tools_opts, hooks_opts, false,
+        )?))
     }
 
     /// Extract the runtime config for the serve system based on all config layers.
     pub fn rtc_serve(
-        cli_build: ConfigOptsBuild, cli_watch: ConfigOptsWatch, cli_serve: ConfigOptsServe, config: Option<PathBuf>,
+        cli_build: ConfigOptsBuild,
+        cli_watch: ConfigOptsWatch,
+        cli_serve: ConfigOptsServe,
+        config: Option<PathBuf>,
     ) -> Result<Arc<RtcServe>> {
         let base_layer = Self::file_and_env_layers(config)?;
         let build_layer = Self::cli_opts_layer_build(cli_build, base_layer);
@@ -273,7 +284,10 @@ impl ConfigOpts {
     }
 
     fn cli_opts_layer_watch(cli: ConfigOptsWatch, cfg_base: Self) -> Self {
-        let opts = ConfigOptsWatch { watch: cli.watch, ignore: cli.ignore };
+        let opts = ConfigOptsWatch {
+            watch: cli.watch,
+            ignore: cli.ignore,
+        };
         let cfg = ConfigOpts {
             build: None,
             watch: Some(opts),
@@ -309,7 +323,10 @@ impl ConfigOpts {
     }
 
     fn cli_opts_layer_clean(cli: ConfigOptsClean, cfg_base: Self) -> Self {
-        let opts = ConfigOptsClean { dist: cli.dist, cargo: cli.cargo };
+        let opts = ConfigOptsClean {
+            dist: cli.dist,
+            cargo: cli.cargo,
+        };
         let cfg = ConfigOpts {
             build: None,
             watch: None,
@@ -339,18 +356,27 @@ impl ConfigOpts {
             return Ok(Default::default());
         }
         if !trunk_toml_path.is_absolute() {
-            trunk_toml_path = trunk_toml_path
-                .canonicalize()
-                .with_context(|| format!("error getting canonical path to Trunk config file {:?}", &trunk_toml_path))?;
+            trunk_toml_path = trunk_toml_path.canonicalize().with_context(|| {
+                format!(
+                    "error getting canonical path to Trunk config file {:?}",
+                    &trunk_toml_path
+                )
+            })?;
         }
         let cfg_bytes = std::fs::read(&trunk_toml_path).context("error reading config file")?;
-        let mut cfg: Self = toml::from_slice(&cfg_bytes).context("error reading config file contents as TOML data")?;
+        let mut cfg: Self = toml::from_slice(&cfg_bytes)
+            .context("error reading config file contents as TOML data")?;
         if let Some(parent) = trunk_toml_path.parent() {
             if let Some(build) = cfg.build.as_mut() {
                 if let Some(target) = build.target.as_mut() {
                     if !target.is_absolute() {
-                        *target = std::fs::canonicalize(parent.join(&target))
-                            .with_context(|| format!("error taking canonical path to [build].target {:?} in {:?}", target, trunk_toml_path))?;
+                        *target =
+                            std::fs::canonicalize(parent.join(&target)).with_context(|| {
+                                format!(
+                                    "error taking canonical path to [build].target {:?} in {:?}",
+                                    target, trunk_toml_path
+                                )
+                            })?;
                     }
                 }
                 if let Some(dist) = build.dist.as_mut() {
@@ -363,16 +389,27 @@ impl ConfigOpts {
                 if let Some(watch_paths) = watch.watch.as_mut() {
                     for path in watch_paths.iter_mut() {
                         if !path.is_absolute() {
-                            *path = std::fs::canonicalize(parent.join(&path))
-                                .with_context(|| format!("error taking canonical path to [watch].watch {:?} in {:?}", path, trunk_toml_path))?;
+                            *path =
+                                std::fs::canonicalize(parent.join(&path)).with_context(|| {
+                                    format!(
+                                        "error taking canonical path to [watch].watch {:?} in {:?}",
+                                        path, trunk_toml_path
+                                    )
+                                })?;
                         }
                     }
                 }
                 if let Some(ignore_paths) = watch.ignore.as_mut() {
                     for path in ignore_paths.iter_mut() {
                         if !path.is_absolute() {
-                            *path = std::fs::canonicalize(parent.join(&path))
-                                .with_context(|| format!("error taking canonical path to [watch].ignore {:?} in {:?}", path, trunk_toml_path))?;
+                            *path =
+                                std::fs::canonicalize(parent.join(&path)).with_context(|| {
+                                    format!(
+                                        "error taking canonical path to [watch].ignore {:?} in \
+                                         {:?}",
+                                        path, trunk_toml_path
+                                    )
+                                })?;
                         }
                     }
                 }

--- a/src/config/models_test.rs
+++ b/src/config/models_test.rs
@@ -5,7 +5,8 @@ use crate::config::models::*;
 fn err_bad_trunk_toml_build_target() {
     let cwd = std::env::current_dir().expect("error getting cwd");
     let path = cwd.join("tests").join("data").join("bad-build-target.toml");
-    let err = ConfigOpts::rtc_build(Default::default(), Some(path)).expect_err("expected config to err");
+    let err =
+        ConfigOpts::rtc_build(Default::default(), Some(path)).expect_err("expected config to err");
     let expected_err = format!(
         r#"error taking canonical path to [build].target "index.html" in "{}/tests/data/bad-build-target.toml""#,
         cwd.to_string_lossy(),
@@ -18,7 +19,8 @@ fn err_bad_trunk_toml_build_target() {
 fn err_bad_trunk_toml_watch_path() {
     let cwd = std::env::current_dir().expect("error getting cwd");
     let path = cwd.join("tests").join("data").join("bad-watch-path.toml");
-    let err = ConfigOpts::rtc_watch(Default::default(), Default::default(), Some(path)).expect_err("expected config to err");
+    let err = ConfigOpts::rtc_watch(Default::default(), Default::default(), Some(path))
+        .expect_err("expected config to err");
     let expected_err = format!(
         r#"error taking canonical path to [watch].watch "fake-dir" in "{}/tests/data/bad-watch-path.toml""#,
         cwd.to_string_lossy(),
@@ -31,7 +33,8 @@ fn err_bad_trunk_toml_watch_path() {
 fn err_bad_trunk_toml_watch_ignore() {
     let cwd = std::env::current_dir().expect("error getting cwd");
     let path = cwd.join("tests").join("data").join("bad-watch-ignore.toml");
-    let err = ConfigOpts::rtc_watch(Default::default(), Default::default(), Some(path)).expect_err("expected config to err");
+    let err = ConfigOpts::rtc_watch(Default::default(), Default::default(), Some(path))
+        .expect_err("expected config to err");
     let expected_err = format!(
         r#"error taking canonical path to [watch].ignore "fake.html" in "{}/tests/data/bad-watch-ignore.toml""#,
         cwd.to_string_lossy(),

--- a/src/config/rt.rs
+++ b/src/config/rt.rs
@@ -6,7 +6,10 @@ use std::sync::Arc;
 use anyhow::{anyhow, Context, Result};
 use axum::http::Uri;
 
-use crate::config::{ConfigOptsBuild, ConfigOptsClean, ConfigOptsHook, ConfigOptsProxy, ConfigOptsServe, ConfigOptsTools, ConfigOptsWatch};
+use crate::config::{
+    ConfigOptsBuild, ConfigOptsClean, ConfigOptsHook, ConfigOptsProxy, ConfigOptsServe,
+    ConfigOptsTools, ConfigOptsWatch,
+};
 
 /// Runtime config for the build system.
 #[derive(Clone, Debug)]
@@ -43,12 +46,20 @@ pub struct RtcBuild {
 
 impl RtcBuild {
     /// Construct a new instance.
-    pub(super) fn new(opts: ConfigOptsBuild, tools: ConfigOptsTools, hooks: Vec<ConfigOptsHook>, inject_autoloader: bool) -> Result<Self> {
+    pub(super) fn new(
+        opts: ConfigOptsBuild,
+        tools: ConfigOptsTools,
+        hooks: Vec<ConfigOptsHook>,
+        inject_autoloader: bool,
+    ) -> Result<Self> {
         // Get the canonical path to the target HTML file.
         let pre_target = opts.target.clone().unwrap_or_else(|| "index.html".into());
-        let target = pre_target
-            .canonicalize()
-            .with_context(|| format!("error getting canonical path to source HTML file {:?}", &pre_target))?;
+        let target = pre_target.canonicalize().with_context(|| {
+            format!(
+                "error getting canonical path to source HTML file {:?}",
+                &pre_target
+            )
+        })?;
 
         // Get the target HTML's parent dir, falling back to OS specific root, as that is the only
         // time where no parent could be determined.
@@ -60,9 +71,13 @@ impl RtcBuild {
         // Ensure the final dist dir exists and that we have a canonical path to the dir. Normally
         // we would want to avoid such an action at this layer, however to ensure that other layers
         // have a reliable FS path to work with, we make an exception here.
-        let final_dist = opts.dist.unwrap_or_else(|| target_parent.join(super::DIST_DIR));
+        let final_dist = opts
+            .dist
+            .unwrap_or_else(|| target_parent.join(super::DIST_DIR));
         if !final_dist.exists() {
-            std::fs::create_dir(&final_dist).with_context(|| format!("error creating final dist directory {:?}", &final_dist))?;
+            std::fs::create_dir(&final_dist).with_context(|| {
+                format!("error creating final dist directory {:?}", &final_dist)
+            })?;
         }
         let final_dist = final_dist
             .canonicalize()
@@ -99,7 +114,11 @@ pub struct RtcWatch {
 
 impl RtcWatch {
     pub(super) fn new(
-        build_opts: ConfigOptsBuild, opts: ConfigOptsWatch, tools: ConfigOptsTools, hooks: Vec<ConfigOptsHook>, inject_autoloader: bool,
+        build_opts: ConfigOptsBuild,
+        opts: ConfigOptsWatch,
+        tools: ConfigOptsTools,
+        hooks: Vec<ConfigOptsHook>,
+        inject_autoloader: bool,
     ) -> Result<Self> {
         let build = Arc::new(RtcBuild::new(build_opts, tools, hooks, inject_autoloader)?);
 
@@ -119,20 +138,26 @@ impl RtcWatch {
         // Take the canonical path of each of the specified ignore targets.
         let mut ignored_paths = match opts.ignore {
             None => vec![],
-            Some(paths) => paths
-                .into_iter()
-                .try_fold(vec![], |mut acc, path| -> Result<Vec<PathBuf>> {
-                    let canon_path = path
-                        .canonicalize()
-                        .map_err(|_| anyhow!("invalid ignore path provided: {:?}", path))?;
-                    acc.push(canon_path);
-                    Ok(acc)
-                })?,
+            Some(paths) => {
+                paths
+                    .into_iter()
+                    .try_fold(vec![], |mut acc, path| -> Result<Vec<PathBuf>> {
+                        let canon_path = path
+                            .canonicalize()
+                            .map_err(|_| anyhow!("invalid ignore path provided: {:?}", path))?;
+                        acc.push(canon_path);
+                        Ok(acc)
+                    })?
+            }
         };
         // Ensure the final dist dir is always ignored.
         ignored_paths.push(build.final_dist.clone());
 
-        Ok(Self { build, paths, ignored_paths })
+        Ok(Self {
+            build,
+            paths,
+            ignored_paths,
+        })
     }
 }
 
@@ -161,10 +186,20 @@ pub struct RtcServe {
 
 impl RtcServe {
     pub(super) fn new(
-        build_opts: ConfigOptsBuild, watch_opts: ConfigOptsWatch, opts: ConfigOptsServe, tools: ConfigOptsTools, hooks: Vec<ConfigOptsHook>,
+        build_opts: ConfigOptsBuild,
+        watch_opts: ConfigOptsWatch,
+        opts: ConfigOptsServe,
+        tools: ConfigOptsTools,
+        hooks: Vec<ConfigOptsHook>,
         proxies: Option<Vec<ConfigOptsProxy>>,
     ) -> Result<Self> {
-        let watch = Arc::new(RtcWatch::new(build_opts, watch_opts, tools, hooks, !opts.no_autoreload)?);
+        let watch = Arc::new(RtcWatch::new(
+            build_opts,
+            watch_opts,
+            tools,
+            hooks,
+            !opts.no_autoreload,
+        )?);
         Ok(Self {
             watch,
             address: opts.address.unwrap_or(IpAddr::V4(Ipv4Addr::LOCALHOST)),

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,4 +1,5 @@
-use std::{process::Stdio, sync::Arc};
+use std::process::Stdio;
+use std::sync::Arc;
 
 use anyhow::{bail, Context, Result};
 use futures::stream::FuturesUnordered;

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,15 +28,17 @@ async fn main() -> Result<()> {
 
     tracing_subscriber::registry()
         // Filter spans based on the RUST_LOG env var.
-        .with(tracing_subscriber::EnvFilter::new(
-            if cli.v { "error,trunk=debug" } else { "error,trunk=info" }
-        ))
+        .with(tracing_subscriber::EnvFilter::new(if cli.v {
+            "error,trunk=debug"
+        } else {
+            "error,trunk=info"
+        }))
         // Send a copy of all spans to stdout as JSON.
         .with(
             tracing_subscriber::fmt::layer()
                 .with_target(false)
                 .with_level(true)
-                .compact()
+                .compact(),
         )
         // Install this registry as the global tracing registry.
         .try_init()

--- a/src/pipelines/copy_dir.rs
+++ b/src/pipelines/copy_dir.rs
@@ -8,8 +8,7 @@ use nipper::Document;
 use tokio::fs;
 use tokio::task::JoinHandle;
 
-use super::ATTR_HREF;
-use super::{LinkAttrs, TrunkLinkPipelineOutput};
+use super::{LinkAttrs, TrunkLinkPipelineOutput, ATTR_HREF};
 use crate::common::copy_dir_recursive;
 use crate::config::RtcBuild;
 
@@ -26,11 +25,16 @@ pub struct CopyDir {
 impl CopyDir {
     pub const TYPE_COPY_DIR: &'static str = "copy-dir";
 
-    pub async fn new(cfg: Arc<RtcBuild>, html_dir: Arc<PathBuf>, attrs: LinkAttrs, id: usize) -> Result<Self> {
+    pub async fn new(
+        cfg: Arc<RtcBuild>,
+        html_dir: Arc<PathBuf>,
+        attrs: LinkAttrs,
+        id: usize,
+    ) -> Result<Self> {
         // Build the path to the target asset.
-        let href_attr = attrs
-            .get(ATTR_HREF)
-            .context(r#"required attr `href` missing for <link data-trunk rel="copydir" .../> element"#)?;
+        let href_attr = attrs.get(ATTR_HREF).context(
+            r#"required attr `href` missing for <link data-trunk rel="copydir" .../> element"#,
+        )?;
         let mut path = PathBuf::new();
         path.extend(href_attr.split('/'));
         if !path.is_absolute() {
@@ -51,12 +55,12 @@ impl CopyDir {
         let rel_path = crate::common::strip_prefix(&self.path);
         tracing::info!(path = ?rel_path, "copying directory");
 
-        let canonical_path = fs::canonicalize(&self.path)
-            .await
-            .with_context(|| format!("error taking canonical path of directory {:?}", &self.path))?;
-        let dir_name = canonical_path
-            .file_name()
-            .with_context(|| format!("could not get directory name of dir {:?}", &canonical_path))?;
+        let canonical_path = fs::canonicalize(&self.path).await.with_context(|| {
+            format!("error taking canonical path of directory {:?}", &self.path)
+        })?;
+        let dir_name = canonical_path.file_name().with_context(|| {
+            format!("could not get directory name of dir {:?}", &canonical_path)
+        })?;
         let dir_out = self.cfg.staging_dist.join(dir_name);
         copy_dir_recursive(canonical_path, dir_out).await?;
 

--- a/src/pipelines/copy_file.rs
+++ b/src/pipelines/copy_file.rs
@@ -7,8 +7,7 @@ use anyhow::{Context, Result};
 use nipper::Document;
 use tokio::task::JoinHandle;
 
-use super::ATTR_HREF;
-use super::{AssetFile, LinkAttrs, TrunkLinkPipelineOutput};
+use super::{AssetFile, LinkAttrs, TrunkLinkPipelineOutput, ATTR_HREF};
 use crate::config::RtcBuild;
 
 /// A CopyFile asset pipeline.
@@ -24,11 +23,16 @@ pub struct CopyFile {
 impl CopyFile {
     pub const TYPE_COPY_FILE: &'static str = "copy-file";
 
-    pub async fn new(cfg: Arc<RtcBuild>, html_dir: Arc<PathBuf>, attrs: LinkAttrs, id: usize) -> Result<Self> {
+    pub async fn new(
+        cfg: Arc<RtcBuild>,
+        html_dir: Arc<PathBuf>,
+        attrs: LinkAttrs,
+        id: usize,
+    ) -> Result<Self> {
         // Build the path to the target asset.
-        let href_attr = attrs
-            .get(ATTR_HREF)
-            .context(r#"required attr `href` missing for <link data-trunk rel="copyfile" .../> element"#)?;
+        let href_attr = attrs.get(ATTR_HREF).context(
+            r#"required attr `href` missing for <link data-trunk rel="copyfile" .../> element"#,
+        )?;
         let mut path = PathBuf::new();
         path.extend(href_attr.split('/'));
         let asset = AssetFile::new(&html_dir, path).await?;

--- a/src/pipelines/css.rs
+++ b/src/pipelines/css.rs
@@ -7,8 +7,7 @@ use anyhow::{Context, Result};
 use nipper::Document;
 use tokio::task::JoinHandle;
 
-use super::ATTR_HREF;
-use super::{AssetFile, HashedFileOutput, LinkAttrs, TrunkLinkPipelineOutput};
+use super::{AssetFile, HashedFileOutput, LinkAttrs, TrunkLinkPipelineOutput, ATTR_HREF};
 use crate::config::RtcBuild;
 
 /// A CSS asset pipeline.
@@ -24,11 +23,16 @@ pub struct Css {
 impl Css {
     pub const TYPE_CSS: &'static str = "css";
 
-    pub async fn new(cfg: Arc<RtcBuild>, html_dir: Arc<PathBuf>, attrs: LinkAttrs, id: usize) -> Result<Self> {
+    pub async fn new(
+        cfg: Arc<RtcBuild>,
+        html_dir: Arc<PathBuf>,
+        attrs: LinkAttrs,
+        id: usize,
+    ) -> Result<Self> {
         // Build the path to the target asset.
-        let href_attr = attrs
-            .get(ATTR_HREF)
-            .context(r#"required attr `href` missing for <link data-trunk rel="css" .../> element"#)?;
+        let href_attr = attrs.get(ATTR_HREF).context(
+            r#"required attr `href` missing for <link data-trunk rel="css" .../> element"#,
+        )?;
         let mut path = PathBuf::new();
         path.extend(href_attr.split('/'));
         let asset = AssetFile::new(&html_dir, path).await?;
@@ -68,11 +72,12 @@ pub struct CssOutput {
 
 impl CssOutput {
     pub async fn finalize(self, dom: &mut Document) -> Result<()> {
-        dom.select(&super::trunk_id_selector(self.id)).replace_with_html(format!(
-            r#"<link rel="stylesheet" href="{base}{file}"/>"#,
-            base = &self.cfg.public_url,
-            file = self.file.file_name
-        ));
+        dom.select(&super::trunk_id_selector(self.id))
+            .replace_with_html(format!(
+                r#"<link rel="stylesheet" href="{base}{file}"/>"#,
+                base = &self.cfg.public_url,
+                file = self.file.file_name
+            ));
         Ok(())
     }
 }

--- a/src/pipelines/icon.rs
+++ b/src/pipelines/icon.rs
@@ -7,8 +7,7 @@ use anyhow::{Context, Result};
 use nipper::Document;
 use tokio::task::JoinHandle;
 
-use super::ATTR_HREF;
-use super::{AssetFile, HashedFileOutput, LinkAttrs, TrunkLinkPipelineOutput};
+use super::{AssetFile, HashedFileOutput, LinkAttrs, TrunkLinkPipelineOutput, ATTR_HREF};
 use crate::config::RtcBuild;
 
 /// An Icon asset pipeline.
@@ -24,11 +23,16 @@ pub struct Icon {
 impl Icon {
     pub const TYPE_ICON: &'static str = "icon";
 
-    pub async fn new(cfg: Arc<RtcBuild>, html_dir: Arc<PathBuf>, attrs: LinkAttrs, id: usize) -> Result<Self> {
+    pub async fn new(
+        cfg: Arc<RtcBuild>,
+        html_dir: Arc<PathBuf>,
+        attrs: LinkAttrs,
+        id: usize,
+    ) -> Result<Self> {
         // Build the path to the target asset.
-        let href_attr = attrs
-            .get(ATTR_HREF)
-            .context(r#"required attr `href` missing for <link data-trunk rel="icon" .../> element"#)?;
+        let href_attr = attrs.get(ATTR_HREF).context(
+            r#"required attr `href` missing for <link data-trunk rel="icon" .../> element"#,
+        )?;
         let mut path = PathBuf::new();
         path.extend(href_attr.split('/'));
         let asset = AssetFile::new(&html_dir, path).await?;
@@ -68,11 +72,12 @@ pub struct IconOutput {
 
 impl IconOutput {
     pub async fn finalize(self, dom: &mut Document) -> Result<()> {
-        dom.select(&super::trunk_id_selector(self.id)).replace_with_html(format!(
-            r#"<link rel="icon" href="{base}{file}"/>"#,
-            base = &self.cfg.public_url,
-            file = self.file.file_name
-        ));
+        dom.select(&super::trunk_id_selector(self.id))
+            .replace_with_html(format!(
+                r#"<link rel="icon" href="{base}{file}"/>"#,
+                base = &self.cfg.public_url,
+                file = self.file.file_name
+            ));
         Ok(())
     }
 }

--- a/src/pipelines/inline.rs
+++ b/src/pipelines/inline.rs
@@ -25,17 +25,22 @@ impl Inline {
     pub const TYPE_INLINE: &'static str = "inline";
 
     pub async fn new(html_dir: Arc<PathBuf>, attrs: LinkAttrs, id: usize) -> Result<Self> {
-        let href_attr = attrs
-            .get(ATTR_HREF)
-            .context(r#"required attr `href` missing for <link data-trunk rel="inline" .../> element"#)?;
+        let href_attr = attrs.get(ATTR_HREF).context(
+            r#"required attr `href` missing for <link data-trunk rel="inline" .../> element"#,
+        )?;
 
         let mut path = PathBuf::new();
         path.extend(href_attr.split('/'));
 
         let asset = AssetFile::new(&html_dir, path).await?;
-        let content_type = ContentType::from_attr_or_ext(attrs.get(ATTR_TYPE), asset.ext.as_deref())?;
+        let content_type =
+            ContentType::from_attr_or_ext(attrs.get(ATTR_TYPE), asset.ext.as_deref())?;
 
-        Ok(Self { id, asset, content_type })
+        Ok(Self {
+            id,
+            asset,
+            content_type,
+        })
     }
 
     /// Spawn the pipeline for this asset type.
@@ -120,7 +125,8 @@ impl InlineOutput {
             ContentType::Js => format!(r#"<script>{}</script>"#, self.content),
         };
 
-        dom.select(&super::trunk_id_selector(self.id)).replace_with_html(html);
+        dom.select(&super::trunk_id_selector(self.id))
+            .replace_with_html(html);
         Ok(())
     }
 }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -37,8 +37,16 @@ impl ServeSystem {
     /// Construct a new instance.
     pub async fn new(cfg: Arc<RtcServe>, shutdown: broadcast::Sender<()>) -> Result<Self> {
         let (build_done_chan, _) = broadcast::channel(8);
-        let watch = WatchSystem::new(cfg.watch.clone(), shutdown.clone(), Some(build_done_chan.clone())).await?;
-        let http_addr = format!("http://{}:{}{}", cfg.address, cfg.port, &cfg.watch.build.public_url);
+        let watch = WatchSystem::new(
+            cfg.watch.clone(),
+            shutdown.clone(),
+            Some(build_done_chan.clone()),
+        )
+        .await?;
+        let http_addr = format!(
+            "http://{}:{}{}",
+            cfg.address, cfg.port, &cfg.watch.build.public_url
+        );
         Ok(Self {
             cfg,
             watch,
@@ -54,7 +62,11 @@ impl ServeSystem {
         // Spawn the watcher & the server.
         let _build_res = self.watch.build().await; // TODO: only open after a successful build.
         let watch_handle = tokio::spawn(self.watch.run());
-        let server_handle = Self::spawn_server(self.cfg.clone(), self.shutdown_tx.subscribe(), self.build_done_chan)?;
+        let server_handle = Self::spawn_server(
+            self.cfg.clone(),
+            self.shutdown_tx.subscribe(),
+            self.build_done_chan,
+        )?;
 
         // Open the browser.
         if self.cfg.open {
@@ -73,7 +85,11 @@ impl ServeSystem {
     }
 
     #[tracing::instrument(level = "trace", skip(cfg, shutdown_rx))]
-    fn spawn_server(cfg: Arc<RtcServe>, mut shutdown_rx: broadcast::Receiver<()>, build_done_chan: broadcast::Sender<()>) -> Result<JoinHandle<()>> {
+    fn spawn_server(
+        cfg: Arc<RtcServe>,
+        mut shutdown_rx: broadcast::Receiver<()>,
+        build_done_chan: broadcast::Sender<()>,
+    ) -> Result<JoinHandle<()>> {
         // Build a shutdown signal for the warp server.
         let shutdown_fut = async move {
             // Any event on this channel, even a drop, should trigger shutdown.
@@ -127,7 +143,13 @@ pub struct State {
 
 impl State {
     /// Construct a new instance.
-    pub fn new(dist_dir: PathBuf, public_url: String, client: reqwest::Client, cfg: &RtcServe, build_done_chan: broadcast::Sender<()>) -> Self {
+    pub fn new(
+        dist_dir: PathBuf,
+        public_url: String,
+        client: reqwest::Client,
+        cfg: &RtcServe,
+        build_done_chan: broadcast::Sender<()>,
+    ) -> Self {
         Self {
             client,
             dist_dir,
@@ -154,7 +176,11 @@ async fn serve_dist(req: Request<Body>) -> ServerResult<Response<Body>> {
     // for HTML to be returned, then move on to attempt to serve the index.html. Else, respond.
     match (&res, accept_header_opt) {
         // If accept does not contain `*/*` or `text/html`, then return.
-        (ResolveResult::NotFound, Some(Ok(accept_header))) if accept_header.contains("*/*") || accept_header.contains("text/html") => (),
+        (ResolveResult::NotFound, Some(Ok(accept_header)))
+            if accept_header.contains("*/*") || accept_header.contains("text/html") =>
+        {
+            ()
+        }
         _ => {
             return Ok(ResponseBuilder::new()
                 .request(&req)
@@ -163,7 +189,8 @@ async fn serve_dist(req: Request<Body>) -> ServerResult<Response<Body>> {
         }
     };
 
-    // At this point, we have a 404 with an accept header allowing HTML, so attempt to serve the index.
+    // At this point, we have a 404 with an accept header allowing HTML, so attempt to serve the
+    // index.
     let res = resolve_path(state.dist_dir.as_path(), INDEX_HTML)
         .await
         .context("error serving index.html from dist dir")?;
@@ -180,42 +207,78 @@ fn router(state: Arc<State>, cfg: Arc<RtcServe>) -> Router {
     let public_route = if state.public_url == "/" {
         &state.public_url
     } else {
-        state.public_url.strip_suffix('/').unwrap_or(&state.public_url)
+        state
+            .public_url
+            .strip_suffix('/')
+            .unwrap_or(&state.public_url)
     };
 
     let mut router = Router::new()
-        .fallback(Router::new().nest(public_route, get(serve_dist.layer(TraceLayer::new_for_http()))))
+        .fallback(Router::new().nest(
+            public_route,
+            get(serve_dist.layer(TraceLayer::new_for_http())),
+        ))
         .route(
             "/_trunk/ws",
-            get(|ws: WebSocketUpgrade, state: Extension<Arc<State>>| async move {
-                ws.on_upgrade(|socket| async move { handle_ws(socket, state.0).await })
-            }),
+            get(
+                |ws: WebSocketUpgrade, state: Extension<Arc<State>>| async move {
+                    ws.on_upgrade(|socket| async move { handle_ws(socket, state.0).await })
+                },
+            ),
         )
         .layer(Extension(state.clone()));
 
-    tracing::info!("{} serving static assets at -> {}", SERVER, state.public_url.as_str());
+    tracing::info!(
+        "{} serving static assets at -> {}",
+        SERVER,
+        state.public_url.as_str()
+    );
 
     // Build proxies.
     if let Some(backend) = &cfg.proxy_backend {
         if cfg.proxy_ws {
             let handler = ProxyHandlerWebSocket::new(backend.clone(), cfg.proxy_rewrite.clone());
             router = handler.clone().register(router);
-            tracing::info!("{} proxying websocket {} -> {}", SERVER, handler.path(), &backend);
+            tracing::info!(
+                "{} proxying websocket {} -> {}",
+                SERVER,
+                handler.path(),
+                &backend
+            );
         } else {
-            let handler = ProxyHandlerHttp::new(state.client.clone(), backend.clone(), cfg.proxy_rewrite.clone());
+            let handler = ProxyHandlerHttp::new(
+                state.client.clone(),
+                backend.clone(),
+                cfg.proxy_rewrite.clone(),
+            );
             router = handler.clone().register(router);
             tracing::info!("{} proxying {} -> {}", SERVER, handler.path(), &backend);
         }
     } else if let Some(proxies) = &cfg.proxies {
         for proxy in proxies.iter() {
             if proxy.ws {
-                let handler = ProxyHandlerWebSocket::new(proxy.backend.clone(), proxy.rewrite.clone());
+                let handler =
+                    ProxyHandlerWebSocket::new(proxy.backend.clone(), proxy.rewrite.clone());
                 router = handler.clone().register(router);
-                tracing::info!("{} proxying websocket {} -> {}", SERVER, handler.path(), &proxy.backend);
+                tracing::info!(
+                    "{} proxying websocket {} -> {}",
+                    SERVER,
+                    handler.path(),
+                    &proxy.backend
+                );
             } else {
-                let handler = ProxyHandlerHttp::new(state.client.clone(), proxy.backend.clone(), proxy.rewrite.clone());
+                let handler = ProxyHandlerHttp::new(
+                    state.client.clone(),
+                    proxy.backend.clone(),
+                    proxy.rewrite.clone(),
+                );
                 router = handler.clone().register(router);
-                tracing::info!("{} proxying {} -> {}", SERVER, handler.path(), &proxy.backend);
+                tracing::info!(
+                    "{} proxying {} -> {}",
+                    SERVER,
+                    handler.path(),
+                    &proxy.backend
+                );
             };
         }
     }
@@ -233,7 +296,9 @@ async fn handle_ws(mut ws: WebSocket, state: Arc<State>) {
         }
         build_done = rx.recv() => build_done.is_ok(),
     } {
-        let ws_send = ws.send(axum::extract::ws::Message::Text(r#"{"reload": true}"#.to_owned()));
+        let ws_send = ws.send(axum::extract::ws::Message::Text(
+            r#"{"reload": true}"#.to_owned(),
+        ));
         if ws_send.await.is_err() {
             break;
         }

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -33,7 +33,11 @@ pub struct WatchSystem {
 
 impl WatchSystem {
     /// Create a new instance.
-    pub async fn new(cfg: Arc<RtcWatch>, shutdown: broadcast::Sender<()>, build_done_tx: Option<broadcast::Sender<()>>) -> Result<Self> {
+    pub async fn new(
+        cfg: Arc<RtcWatch>,
+        shutdown: broadcast::Sender<()>,
+        build_done_tx: Option<broadcast::Sender<()>>,
+    ) -> Result<Self> {
         // Create a channel for being able to listen for new paths to ignore while running.
         let (watch_tx, watch_rx) = mpsc::channel(1);
         let (build_tx, build_rx) = mpsc::channel(1);
@@ -76,7 +80,10 @@ impl WatchSystem {
 
     #[tracing::instrument(level = "trace", skip(self, event))]
     async fn handle_watch_event(&mut self, event: Event) {
-        if matches!(&event.kind, EventKind::Access(_) | EventKind::Any | EventKind::Other) {
+        if matches!(
+            &event.kind,
+            EventKind::Access(_) | EventKind::Any | EventKind::Other
+        ) {
             return; // Nothing to do with these.
         }
 
@@ -89,10 +96,11 @@ impl WatchSystem {
             };
 
             // Check ignored paths.
-            if ev_path
-                .ancestors()
-                .any(|path| self.ignored_paths.iter().any(|ignored_path| ignored_path == path))
-            {
+            if ev_path.ancestors().any(|path| {
+                self.ignored_paths
+                    .iter()
+                    .any(|ignored_path| ignored_path == path)
+            }) {
                 continue; // Don't emit a notification if path is ignored.
             }
 
@@ -140,7 +148,8 @@ fn build_watcher(watch_tx: mpsc::Sender<Event>, paths: Vec<PathBuf>) -> Result<R
             tracing::error!(error = ?err, "error from FS watcher");
         }
     };
-    let mut watcher = recommended_watcher(event_handler).context("failed to build file system watcher")?;
+    let mut watcher =
+        recommended_watcher(event_handler).context("failed to build file system watcher")?;
 
     // Create a recursive watcher on each of the given paths.
     // NOTE WELL: it is expected that all given paths are canonical. The Trunk config
@@ -149,7 +158,10 @@ fn build_watcher(watch_tx: mpsc::Sender<Event>, paths: Vec<PathBuf>) -> Result<R
     for path in paths {
         watcher
             .watch(&path, RecursiveMode::Recursive)
-            .context(format!("failed to watch {:?} for file system changes", path))?;
+            .context(format!(
+                "failed to watch {:?} for file system changes",
+                path
+            ))?;
     }
 
     Ok(watcher)


### PR DESCRIPTION
This reduces the current amount of customized `rustfmt` settings. It still uses some few nightly only settings but that should be okay.

The main reason here is to stay more close to the default and only use settings that apply some (otherwise not applied) auto-formatting for good measure. Other limits or greatly imacting settings are removed.

I think this increases readability a bit too, but that may be very subjective as I'm simply more used to the default formatting and automatically find it more natural. Therefore, it would be great if @thedodd could have a quick look over this.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [ ] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [ ] Updated `site` content with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
