### PR TITLE
Add strip-debug and strip-dwarf to wasm-opt call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 - Added the `--address` option for `trunk serve`.
 - Open autoreload websocket using wss when assets are served over a secure connection.
 - Added the `data-type` attribute to Rust assets. Can be set to either `main` (previous behaviour and default) or `worker`, which builds the asset and includes it as a web worker.
+- Include `--strip-debug` and `--strip-dwarf` passes when running `wasm-opt`.
 
 ### changed
 - Bump notify to 5.0.0-pre.13, which fixes [notify-rs/notify#356](https://github.com/notify-rs/notify/issues/356)
@@ -17,6 +18,9 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 - Force HTTP/1 on proxy client, which fixes [#280](https://github.com/thedodd/trunk/issues/280)
 - Print the serving address with a protocol to make it to be recognized as an URL in some terminals [#292](https://github.com/thedodd/trunk/issues/292)
 - Verify the target architecture when downloading tools in addition to the OS and fail if the architecture doesn't match.
+
+### fixed
+- When no explicit `rel="rust"` link is given, the default `wasm-opt` level as determined by the build type is respected, instead of being turned off.
 
 ## 0.14.0
 ### added

--- a/src/pipelines/rust.rs
+++ b/src/pipelines/rust.rs
@@ -138,7 +138,7 @@ impl RustApp {
             bin: None,
             keep_debug: false,
             no_demangle: false,
-            wasm_opt: WasmOptLevel::Off,
+            wasm_opt: WasmOptLevel::Default,
             app_type: RustAppType::Main,
             name,
         })
@@ -363,7 +363,11 @@ impl RustApp {
         let arg_output = format!("--output={}", output);
         let arg_opt_level = format!("-O{}", self.wasm_opt.as_ref());
         let target_wasm = self.cfg.staging_dist.join(hashed_name).to_string_lossy().to_string();
-        let args = vec![&arg_output, &arg_opt_level, &target_wasm];
+        let mut args = vec![arg_output.as_str(), arg_opt_level.as_str(), target_wasm.as_str()];
+        if !self.keep_debug {
+            // Strip additional debug sections, including "function names" section
+            args.extend(["--strip-debug", "--strip-dwarf"]);
+        }
 
         // Invoke wasm-opt.
         tracing::info!("calling wasm-opt");


### PR DESCRIPTION
Adds the `--strip-debug` and `--strip-dwarf` flags to the call to `wasm-opt`. Addtionally fixes the default optlevel for implicitly collected crates, cause I needed this during tests.

Especially the "function names" section can be quite heavy and serves no purpose in release builds. This small flag can easily shrink the build output by several dozen kilobytes.

**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [ ] Updated `site` content with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
