### PR TITLE
Move back from `directories-next` to `directories`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,20 +438,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "directories-next"
-version = "2.0.0"
+name = "directories"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
+checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
 dependencies = [
- "cfg-if 1.0.0",
- "dirs-sys-next",
+ "dirs-sys",
 ]
 
 [[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
+name = "dirs-sys"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
  "redox_users",
@@ -2522,7 +2521,7 @@ dependencies = [
  "cargo_metadata",
  "clap",
  "console",
- "directories-next",
+ "directories",
  "dunce",
  "envy",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ cargo-lock = "7"
 cargo_metadata = "0.14"
 clap = { version = "3", features = ["derive", "env"] }
 console = "0.15"
-directories-next = "2"
+directories = "4"
 dunce = "1"
 envy = "0.4"
 flate2 = "1"

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use anyhow::{bail, ensure, Context, Result};
-use directories_next::ProjectDirs;
+use directories::ProjectDirs;
 use futures::prelude::*;
 use once_cell::sync::Lazy;
 use tokio::fs::File;


### PR DESCRIPTION
Originally `directories-next` was created because `directories` was abandoned. The project got new maintainers and is active again now. Instead `directories-next` became rather stale.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [ ] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [ ] Updated `site` content with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
