### PR TITLE
Allow to disable hashes in output file names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 - Added the `data-type` attribute to Rust assets. Can be set to either `main` (previous behaviour and default) or `worker`, which builds the asset and includes it as a web worker.
 - Added the `--proxy-insecure` option for `trunk serve`.
 - Added the `insecure` option to the `proxy` section in `Trunk.toml`.
+- It is now possible to disable the hashes in output file names with the new `--filehash` flag (for example `cargo build --filehash false`). Alternatively the `build.filehash` setting in `Trunk.toml` or the env var `CARGO_BUILD_FILEHASH` can be used.
 
 ### changed
 - Bump notify to 5.0.0-pre.13, which fixes [notify-rs/notify#356](https://github.com/notify-rs/notify/issues/356)

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -9,6 +9,8 @@ release = false
 dist = "dist"
 # The public URL from which assets are to be served.
 public_url = "/"
+# Whether to include hash values in the output file names.
+filehash = true
 
 [watch]
 # Paths to watch. The `build.target`'s parent folder is watched by default.

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -29,6 +29,9 @@ pub struct ConfigOptsBuild {
     /// The public URL from which assets are to be served [default: /]
     #[clap(long, parse(from_str=parse_public_url))]
     pub public_url: Option<String>,
+    /// Whether to include hash values in the output file names [default: true]
+    #[clap(long)]
+    pub filehash: Option<bool>,
     /// Optional pattern for the app loader script [default: None]
     ///
     /// Patterns should include the sequences `{base}`, `{wasm}`, and `{js}` in order to
@@ -274,6 +277,7 @@ impl ConfigOpts {
             release: cli.release,
             dist: cli.dist,
             public_url: cli.public_url,
+            filehash: cli.filehash,
             pattern_script: cli.pattern_script,
             pattern_preload: cli.pattern_preload,
             pattern_params: cli.pattern_params,
@@ -454,6 +458,7 @@ impl ConfigOpts {
                 g.target = g.target.or(l.target);
                 g.dist = g.dist.or(l.dist);
                 g.public_url = g.public_url.or(l.public_url);
+                g.filehash = g.filehash.or(l.filehash);
                 // NOTE: this can not be disabled in the cascade.
                 if l.release {
                     g.release = true;

--- a/src/config/rt.rs
+++ b/src/config/rt.rs
@@ -22,6 +22,7 @@ pub struct RtcBuild {
     pub release: bool,
     /// The public URL from which assets are to be served.
     pub public_url: String,
+    pub filehash: bool,
     /// The directory where final build artifacts are placed after a successful build.
     pub final_dist: PathBuf,
     /// The directory used to stage build artifacts during an active build.
@@ -88,9 +89,10 @@ impl RtcBuild {
             target,
             target_parent,
             release: opts.release,
+            public_url: opts.public_url.unwrap_or_else(|| "/".into()),
+            filehash: opts.filehash.unwrap_or(true),
             staging_dist,
             final_dist,
-            public_url: opts.public_url.unwrap_or_else(|| "/".into()),
             tools,
             hooks,
             inject_autoloader,

--- a/src/pipelines/copy_file.rs
+++ b/src/pipelines/copy_file.rs
@@ -50,7 +50,7 @@ impl CopyFile {
     async fn run(self) -> Result<TrunkLinkPipelineOutput> {
         let rel_path = crate::common::strip_prefix(&self.asset.path);
         tracing::info!(path = ?rel_path, "copying file");
-        let _ = self.asset.copy(&self.cfg.staging_dist).await?;
+        let _ = self.asset.copy(&self.cfg.staging_dist, false).await?;
         tracing::info!(path = ?rel_path, "finished copying file");
         Ok(TrunkLinkPipelineOutput::CopyFile(CopyFileOutput(self.id)))
     }

--- a/src/pipelines/css.rs
+++ b/src/pipelines/css.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result};
 use nipper::Document;
 use tokio::task::JoinHandle;
 
-use super::{AssetFile, HashedFileOutput, LinkAttrs, TrunkLinkPipelineOutput, ATTR_HREF};
+use super::{AssetFile, LinkAttrs, TrunkLinkPipelineOutput, ATTR_HREF};
 use crate::config::RtcBuild;
 
 /// A CSS asset pipeline.
@@ -50,12 +50,15 @@ impl Css {
     async fn run(self) -> Result<TrunkLinkPipelineOutput> {
         let rel_path = crate::common::strip_prefix(&self.asset.path);
         tracing::info!(path = ?rel_path, "copying & hashing css");
-        let hashed_file_output = self.asset.copy_with_hash(&self.cfg.staging_dist).await?;
+        let file = self
+            .asset
+            .copy(&self.cfg.staging_dist, self.cfg.filehash)
+            .await?;
         tracing::info!(path = ?rel_path, "finished copying & hashing css");
         Ok(TrunkLinkPipelineOutput::Css(CssOutput {
             cfg: self.cfg.clone(),
             id: self.id,
-            file: hashed_file_output,
+            file,
         }))
     }
 }
@@ -66,8 +69,8 @@ pub struct CssOutput {
     pub cfg: Arc<RtcBuild>,
     /// The ID of this pipeline.
     pub id: usize,
-    /// Data on the finalized output file.
-    pub file: HashedFileOutput,
+    /// Name the finalized output file.
+    pub file: String,
 }
 
 impl CssOutput {
@@ -76,7 +79,7 @@ impl CssOutput {
             .replace_with_html(format!(
                 r#"<link rel="stylesheet" href="{base}{file}"/>"#,
                 base = &self.cfg.public_url,
-                file = self.file.file_name
+                file = self.file
             ));
         Ok(())
     }

--- a/src/pipelines/icon.rs
+++ b/src/pipelines/icon.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result};
 use nipper::Document;
 use tokio::task::JoinHandle;
 
-use super::{AssetFile, HashedFileOutput, LinkAttrs, TrunkLinkPipelineOutput, ATTR_HREF};
+use super::{AssetFile, LinkAttrs, TrunkLinkPipelineOutput, ATTR_HREF};
 use crate::config::RtcBuild;
 
 /// An Icon asset pipeline.
@@ -50,12 +50,15 @@ impl Icon {
     async fn run(self) -> Result<TrunkLinkPipelineOutput> {
         let rel_path = crate::common::strip_prefix(&self.asset.path);
         tracing::info!(path = ?rel_path, "copying & hashing icon");
-        let hashed_file_output = self.asset.copy_with_hash(&self.cfg.staging_dist).await?;
+        let file = self
+            .asset
+            .copy(&self.cfg.staging_dist, self.cfg.filehash)
+            .await?;
         tracing::info!(path = ?rel_path, "finished copying & hashing icon");
         Ok(TrunkLinkPipelineOutput::Icon(IconOutput {
             cfg: self.cfg.clone(),
             id: self.id,
-            file: hashed_file_output,
+            file,
         }))
     }
 }
@@ -66,8 +69,8 @@ pub struct IconOutput {
     pub cfg: Arc<RtcBuild>,
     /// The ID of this pipeline.
     pub id: usize,
-    /// Data on the finalized output file.
-    pub file: HashedFileOutput,
+    /// Name of the finalized output file.
+    pub file: String,
 }
 
 impl IconOutput {
@@ -76,7 +79,7 @@ impl IconOutput {
             .replace_with_html(format!(
                 r#"<link rel="icon" href="{base}{file}"/>"#,
                 base = &self.cfg.public_url,
-                file = self.file.file_name
+                file = self.file
             ));
         Ok(())
     }

--- a/src/pipelines/rust.rs
+++ b/src/pipelines/rust.rs
@@ -265,7 +265,12 @@ impl RustApp {
         let wasm_bytes = fs::read(&wasm)
             .await
             .context("error reading wasm file for hash generation")?;
-        let hashed_name = format!("{}-{:x}", self.name, seahash::hash(&wasm_bytes));
+        let hashed_name = self
+            .cfg
+            .filehash
+            .then(|| format!("{}-{:x}", self.name, seahash::hash(&wasm_bytes)))
+            .unwrap_or_else(|| self.name.clone());
+
         Ok((wasm.into_std_path_buf(), hashed_name))
     }
 


### PR DESCRIPTION
Add a new `filehash` option, that allows to control the usage of hashes in output files.

By default, most of the pipelines (`css`, `icon`, `sass` and `rust`) include the hash of the dividual file contents in their output file name. This is great for simple caching, but may be problematic when it is required to reference the files by name or in more complex scenarios (for example generating HTML ETags later on).

This feature has been requested several times on GitHub, and especially recently on Discord a lot.

Fixes #247
Fixes #236
Fixes #171
Fixes #136

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [ ] Updated `site` content with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
