### PR TITLE
Remove the unneeded web worker wrapper file

### DIFF
--- a/src/pipelines/rust.rs
+++ b/src/pipelines/rust.rs
@@ -331,18 +331,6 @@ impl RustApp {
         tracing::info!("copying generated wasm-bindgen artifacts");
         let hashed_js_name = format!("{}.js", &hashed_name);
         let hashed_wasm_name = format!("{}_bg.wasm", &hashed_name);
-        if self.app_type == RustAppType::Worker {
-            let worker_wrapper_path = self.cfg.staging_dist.join(format!("{}.js", self.name));
-            let worker_wrapper = format!(
-                "importScripts('{base}{js}');wasm_bindgen('{base}{wasm}');",
-                base = self.cfg.public_url,
-                js = hashed_js_name,
-                wasm = hashed_wasm_name
-            );
-            fs::write(worker_wrapper_path, worker_wrapper)
-                .await
-                .context("error writing worker wrapper")?;
-        }
         let js_loader_path = bindgen_out.join(&hashed_js_name);
         let js_loader_path_dist = self.cfg.staging_dist.join(&hashed_js_name);
         let wasm_path = bindgen_out.join(&hashed_wasm_name);


### PR DESCRIPTION
A forgotten wrapper file for web workers that was initially generated, but was later on decided to not be needed.

Still, it's currently being generated and then wiped out together with the staging directory. We can avoid doing the extra effort of generating an unneeded file.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [ ] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [ ] Updated `site` content with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
