### PR TITLE
Prefer the system tools if no explicit version set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 - Verify the target architecture when downloading tools in addition to the OS and fail if the architecture doesn't match.
 - Updated all dependencies to their latest versions, fixing several potential security issues.
 - Bumped up the default version for the `dart-sass`, `wasm-bindgen` and `wasm-opt` tools to their latest available version.
+- For `wasm-opt` and `dart-sass`, use the system-installed version if no explicit version is set. Previously Trunk would check for a specific default version which was likely to be an older version.
 
 ### fixed
 - Fixing double-builds caused by downgrading from `notify` v5 back to v4, which contains debounce logic for filesystem events.

--- a/src/pipelines/rust.rs
+++ b/src/pipelines/rust.rs
@@ -418,7 +418,7 @@ impl RustApp {
     }
 }
 
-/// Find the appropriate versio of `wasm-bindgen` to use. The version can be found in 3 different
+/// Find the appropriate version of `wasm-bindgen` to use. The version can be found in 3 different
 /// location in order:
 /// - Defined in the `Trunk.toml` as highest priority.
 /// - Located in the `Cargo.lock` if it exists. This is mostly the case as we run `cargo build`


### PR DESCRIPTION
Prefer the system-installed version of `wasm-opt` and `dart-sass` if no explicit version is set.

Previously Trunk would always require an explicit version of these tools, when considering the system-installed variant. Now it will accept any version, as long as the version is not set through `Trunk.toml` or env vars. This helps to avoid installing older versions if the system already provides newer ones. Especially when Trunk wasn't updated in a while.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [ ] Updated `site` content with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
