### PR TITLE
Run nightly version of rustfmt in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,18 +25,25 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-lint-
 
-      - name: Setup | Toolchain
+      - name: Setup | Toolchain (clippy)
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           default: true
-          components: clippy, rustfmt
+          components: clippy
 
       - name: Build | Clippy
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-targets -- -D warnings
+
+      - name: Setup | Toolchain (rustfmt)
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          default: true
+          components: rustfmt
 
       - name: Build | Rustfmt
         run: cargo fmt -- --check


### PR DESCRIPTION
Title pretty much says it all.

Reason behind this is, that we use some nightly features of rustfmt and we miss out on checking these when running on stable. Therefore, running the nightly version instead.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [ ] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [ ] Updated `site` content with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
