### PR TITLE
Fix used serve address key as expected by clap

### DIFF
--- a/Trunk.toml
+++ b/Trunk.toml
@@ -20,7 +20,7 @@ ignore = []
 
 [serve]
 # The address to serve on.
-addr = "127.0.0.1"
+address = "127.0.0.1"
 # The port to serve on.
 port = 8080
 # Open a browser tab once the initial build is complete.


### PR DESCRIPTION
The field of the struct is address and not addr and so must be changed here.
`trunk config show` can be used to confirm this.

See also: https://github.com/thedodd/trunk/blob/c5defe81d877eaf6c3e68979565638d9354a1ceb/src/config/models.rs#L89

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [ ] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [ ] Updated `site` content with pertinent info (may not always apply).
- [ ] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
