### PR TITLE
Added an additional prefix case for public_url to allow relative paths.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 - Updated all dependencies to their latest versions, fixing several potential security issues.
 - Bumped up the default version for the `dart-sass`, `wasm-bindgen` and `wasm-opt` tools to their latest available version.
 - For `wasm-opt` and `dart-sass`, use the system-installed version if no explicit version is set. Previously Trunk would check for a specific default version which was likely to be an older version.
+- `public_url` accepts relative paths starting with `./` instead of coercing them absolute by pre-pending a `/`. [#165](https://github.com/thedodd/trunk/issues/165) [#320](https://github.com/thedodd/trunk/issues/320)
 
 ### fixed
 - Fixing double-builds caused by downgrading from `notify` v5 back to v4, which contains debounce logic for filesystem events.

--- a/src/common.rs
+++ b/src/common.rs
@@ -23,7 +23,12 @@ static CWD: Lazy<PathBuf> =
 
 /// Ensure the given value for `--public-url` is formatted correctly.
 pub fn parse_public_url(val: &str) -> String {
-    let prefix = if !val.starts_with('/') { "/" } else { "" };
+    // If val don't start with a / (absolute) or . (relative) path, default to absolute.
+    let prefix = if !(val.starts_with('/') || val.starts_with("./")) {
+        "/"
+    } else {
+        ""
+    };
     let suffix = if !val.ends_with('/') { "/" } else { "" };
     format!("{}{}{}", prefix, val, suffix)
 }


### PR DESCRIPTION
**Checklist**
- [X] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply). - NA
- [ ] Updated `site` content with pertinent info (may not always apply). - NA
- [X] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.

With this the `public_url` field will remain relative if the path starts with `./`

This supports cases with CDN's such as [itch.io](https://itch.io/docs/creators/html5#common-pitfalls) which requires relative paths to host static files.

Existing users that use `api/taco/` will still have the url coerced to `/api/taco/`. But if they specify `./api/taco/` then `./api/taco/` is used in the output. `.bin/api` is still coerced to `/.bin/api/`, paths must exactly start with `./`.

It may be better to omit the `./` in the output, let me know if that's wanted.

It may be valid to extend the check to be `!(val.starts_with('/') || val.starts_with("./") || val == ".")`, as `trunk build --public-url "."` feels very natural to write, but results in `/./` being emitted.