### PR TITLE
Log args of all executed commands on debug level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 - Updated all dependencies to their latest versions, fixing several potential security issues.
 - Bumped up the default version for the `dart-sass`, `wasm-bindgen` and `wasm-opt` tools to their latest available version.
 - For `wasm-opt` and `dart-sass`, use the system-installed version if no explicit version is set. Previously Trunk would check for a specific default version which was likely to be an older version.
+- All arguments are now logged in verbose mode, whenever an external binary is executed. Use `trunk -v build ...` (or some other sub-command) to try it out.
 
 ### fixed
 - Fixing double-builds caused by downgrading from `notify` v5 back to v4, which contains debounce logic for filesystem events.

--- a/src/common.rs
+++ b/src/common.rs
@@ -127,7 +127,12 @@ pub fn strip_prefix(target: &Path) -> &Path {
 /// Run a global command with the given arguments and make sure it completes successfully. If it
 /// fails an error is returned.
 #[tracing::instrument(level = "trace", skip(name, path, args))]
-pub async fn run_command(name: &str, path: &Path, args: &[impl AsRef<OsStr>]) -> Result<()> {
+pub async fn run_command(
+    name: &str,
+    path: &Path,
+    args: &[impl AsRef<OsStr> + Debug],
+) -> Result<()> {
+    tracing::debug!(?args, "{name} args");
     let status = Command::new(path)
         .args(args)
         .stdout(Stdio::inherit())

--- a/src/pipelines/rust.rs
+++ b/src/pipelines/rust.rs
@@ -343,7 +343,6 @@ impl RustApp {
 
         // Invoke wasm-bindgen.
         tracing::info!("calling wasm-bindgen for {}", self.name);
-        tracing::info!("wasm-bindgen args: {:#?}", &args);
         common::run_command(wasm_bindgen_name, &wasm_bindgen, &args)
             .await
             .map_err(|err| check_target_not_found_err(err, wasm_bindgen_name))?;


### PR DESCRIPTION
In relation to #357, I think it's a good idea to log command arguments whenever an external program is invoked. But instead in verbose mode, as this is most helpful to debug some wrong configuration. 

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [ ] Updated `site` content with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
