### PR TITLE
Remove the CI filter on markdown files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,12 +1,5 @@
 name: CI
-on:
-  push:
-    paths-ignore:
-      - "**.md"
-  pull_request:
-    paths-ignore:
-      - "**.md"
-
+on: [push, pull_request]
 jobs:
   lint:
     name: lint


### PR DESCRIPTION
Remove the filter on Markdown files, as the branch protection rules currently prevent any changes on Markdown files only. Removing this filter will trigger CI, therefore, allowing to merge PRs to Markdown files after the CI passes.

Also, looking at past PRs, it's relatively rare that we have markdown/website only changes, so the extra overhead of running the CI is acceptable.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [ ] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [ ] Updated `site` content with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
