### PR TITLE
Fix for Apple Silicon(M1)

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -18,6 +18,8 @@ wget -qO- https://github.com/thedodd/trunk/releases/download/${VERSION}/trunk-x8
 
 # Install via cargo.
 cargo install --locked trunk
+# For Mac computers with Apple silicon(M1), additional command to run
+cargo install --locked wasm-bindgen-cli
 ```
 <small>Release binaries can be found on the [Github releases page](https://github.com/thedodd/trunk/releases).</small>
 

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -18,7 +18,8 @@ wget -qO- https://github.com/thedodd/trunk/releases/download/${VERSION}/trunk-x8
 
 # Install via cargo.
 cargo install --locked trunk
-# For Mac computers with Apple silicon(M1), additional command to run
+# Until wasm-bindgen has pre-built binaries for Apple M1, M1 users will
+# need to install wasm-bindgen manually.
 cargo install --locked wasm-bindgen-cli
 ```
 <small>Release binaries can be found on the [Github releases page](https://github.com/thedodd/trunk/releases).</small>


### PR DESCRIPTION
When running ```trunk build``` on Apple silicon, build failing with message ```unsupported architecture```. To fix this one has to run ```cargo install --locked wasm-bindgen-cli```. Same has been added to documentation.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [ ] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [ ] Updated `site` content with pertinent info (may not always apply).
- [ ] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
