### PR TITLE
Download native tooling for M1 (arm) MacOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 ## Unreleased
 ### added
+- Support automatic tooling downloads for M1 Macs.
 ### changed
 ### fixed
 


### PR DESCRIPTION
First let me say that Trunk is really cool! The config-via-html mechanism is particularly elegant, nice job!

It seems that https://github.com/thedodd/trunk/pull/275 deliberately broke downloading for architectures besides x86_64, requiring those folks to manually download and install Sass, WasmBindgen, and WasmOpt. (Docs aren't clear on this either, hence https://github.com/thedodd/trunk/pull/375)

However, since WasmOpt and Sass have ARM builds and MacOS has an x86 emulation layer (Rosetta) that'll run WasmBindgen, we can actually support automatic tool downloads for M1 Macs no problem.

I refactored the existing URL-construction code so that it'll (hopefully) read more clearly and isolate the "logic" of URL construction in one place rather than across three methods (`target_os`, `target_arch`, and `url`).

I've tested this on an M1 Mac with a project and verifyed that Trunk downloads Sass, WasmBindgen, and WasmOpt to `~/Library/Caches/dev.trunkrs.trunk` and can run all of 'em successfully.

I haven't yet tested on x86 Mac or any Windows or Linux --- please let me know if that's something I'll need to figure out or if that's easier done in CI or by other folks. Thanks!


**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [n/a] Updated README.md with pertinent info (may not always apply).
- [n/a] Updated `site` content with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
