### PR TITLE
Fix "addr" -> "address" in the default Trunk.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 ### added
 ### changed
 ### fixed
+- Fixed a typo in the example Trunk.toml `addr` -> `address`
 
 ## 0.15.0
 ### added

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -20,7 +20,7 @@ ignore = []
 
 [serve]
 # The address to serve on.
-addr = "127.0.0.1"
+address = "127.0.0.1"
 # The port to serve on.
 port = 8080
 # Open a browser tab once the initial build is complete.


### PR DESCRIPTION
The "addr" field is not working and is silently ignored - the field is actually named "address"

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [ ] Updated `site` content with pertinent info (may not always apply).
- [ ] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
