### PR TITLE
Add reference types support to wasm-opt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 ### added
 ### changed
 ### fixed
+- Enable reference types for `wasm-opt`.
 
 ## 0.15.0
 ### added

--- a/src/pipelines/rust.rs
+++ b/src/pipelines/rust.rs
@@ -438,7 +438,11 @@ impl RustApp {
             .join(hashed_name)
             .to_string_lossy()
             .to_string();
-        let args = vec![&arg_output, &arg_opt_level, &target_wasm];
+        let mut args: Vec<&str> = vec![&arg_output, &arg_opt_level, &target_wasm];
+
+        if self.reference_types {
+            args.push("--enable-reference-types");
+        }
 
         // Invoke wasm-opt.
         tracing::info!("calling wasm-opt");


### PR DESCRIPTION
Ensures that `wasm-opt` is called with the relevant flag when reference types are enabled.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [ ] Updated `site` content with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
