### PR TITLE
Add option `data-target-path` to copy-dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 ## Unreleased
 ### added
+- Added `data-target-path` to `copy-dir`.
 ### changed
 ### fixed
 

--- a/site/content/assets.md
+++ b/site/content/assets.md
@@ -49,6 +49,7 @@ This will typically look like: `<link data-trunk rel="{type}" href="{path}" ..ot
 
 ## copy-dir
 ✅ `rel="copy-dir"`: Trunk will recursively copy the directory specified in the `href` attribute to the `dist` dir. This content is copied exactly, no hashing is performed.
+  - `data-target-path`: (optional) Path where the directory is placed inside the dist dir. If not present the directory is placed in the dist root. The path must be a relative path without `..`.
 
 Trunk is still a young project, and new asset types will be added as we move forward. Keep an eye on [trunk#3](https://github.com/thedodd/trunk/issues/3) for more information on planned asset types, implementation status, and please contribute to the discussion if you think something is missing.
 

--- a/src/pipelines/copy_dir.rs
+++ b/src/pipelines/copy_dir.rs
@@ -1,6 +1,6 @@
 //! Copy-dir asset pipeline.
 
-use std::path::PathBuf;
+use std::path::{Component, PathBuf};
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
@@ -20,6 +20,8 @@ pub struct CopyDir {
     cfg: Arc<RtcBuild>,
     /// The path to the dir being copied.
     path: PathBuf,
+    /// Optional target path inside the dist dir.
+    target_path: Option<PathBuf>,
 }
 
 impl CopyDir {
@@ -40,7 +42,17 @@ impl CopyDir {
         if !path.is_absolute() {
             path = html_dir.join(path);
         }
-        Ok(Self { id, cfg, path })
+        let target_path = attrs
+            .get("data-target-path")
+            .map(|val| val.parse())
+            .transpose()?;
+
+        Ok(Self {
+            id,
+            cfg,
+            path,
+            target_path,
+        })
     }
 
     /// Spawn the pipeline for this asset type.
@@ -61,7 +73,20 @@ impl CopyDir {
         let dir_name = canonical_path.file_name().with_context(|| {
             format!("could not get directory name of dir {:?}", &canonical_path)
         })?;
-        let dir_out = self.cfg.staging_dist.join(dir_name);
+
+        let dir_out = if let Some(path) = self.target_path {
+            if path.is_absolute() || path.components().any(|c| matches!(c, Component::ParentDir)) {
+                anyhow::bail!(
+                    "Invalid data-target-path '{}'. Must be a relative path without '..'.",
+                    path.display()
+                );
+            }
+            let dir_out = self.cfg.staging_dist.join(&path);
+            tokio::fs::create_dir_all(&dir_out).await?;
+            dir_out
+        } else {
+            self.cfg.staging_dist.join(dir_name)
+        };
         copy_dir_recursive(canonical_path, dir_out).await?;
 
         tracing::info!(path = ?rel_path, "finished copying directory");


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
I wanted something like this for sharing an assets folder between multiple projects that each only need a subset of the assets. 

I considered `data-keep-prefix` instead, but this is more flexible and felt simpler to implement.

I'm open to name bikeshedding or another way to achieve the same thing. It might also make sense to add the same functionality to `copy-file`.

**Checklist**
- [X] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [X] Updated `site` content with pertinent info (may not always apply).
- [X] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
