### PR TITLE
Pass attrs through on script tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 ### changed
 - Updated gloo-worker example to use gloo-worker crate v2.1.
 - Our website (trunkrs.dev) now only updates on new releases.
+- Additional attributes are now passed through script tags (fixes #429)
 ### fixed
 - Nested WS proxies - if `backend=ws://localhost:8000/ws` is set, queries for `ws://localhost:8080/ws/entityX` will be linked with `ws://localhost:8000/ws/entityX`
 

--- a/src/pipelines/copy_dir.rs
+++ b/src/pipelines/copy_dir.rs
@@ -8,7 +8,7 @@ use nipper::Document;
 use tokio::fs;
 use tokio::task::JoinHandle;
 
-use super::{LinkAttrs, TrunkAssetPipelineOutput, ATTR_HREF};
+use super::{Attrs, TrunkAssetPipelineOutput, ATTR_HREF};
 use crate::common::copy_dir_recursive;
 use crate::config::RtcBuild;
 
@@ -30,7 +30,7 @@ impl CopyDir {
     pub async fn new(
         cfg: Arc<RtcBuild>,
         html_dir: Arc<PathBuf>,
-        attrs: LinkAttrs,
+        attrs: Attrs,
         id: usize,
     ) -> Result<Self> {
         // Build the path to the target asset.

--- a/src/pipelines/copy_file.rs
+++ b/src/pipelines/copy_file.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result};
 use nipper::Document;
 use tokio::task::JoinHandle;
 
-use super::{AssetFile, LinkAttrs, TrunkAssetPipelineOutput, ATTR_HREF};
+use super::{AssetFile, Attrs, TrunkAssetPipelineOutput, ATTR_HREF};
 use crate::config::RtcBuild;
 
 /// A CopyFile asset pipeline.
@@ -26,7 +26,7 @@ impl CopyFile {
     pub async fn new(
         cfg: Arc<RtcBuild>,
         html_dir: Arc<PathBuf>,
-        attrs: LinkAttrs,
+        attrs: Attrs,
         id: usize,
     ) -> Result<Self> {
         // Build the path to the target asset.

--- a/src/pipelines/css.rs
+++ b/src/pipelines/css.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result};
 use nipper::Document;
 use tokio::task::JoinHandle;
 
-use super::{AssetFile, LinkAttrs, TrunkAssetPipelineOutput, ATTR_HREF};
+use super::{AssetFile, Attrs, TrunkAssetPipelineOutput, ATTR_HREF};
 use crate::config::RtcBuild;
 
 /// A CSS asset pipeline.
@@ -26,7 +26,7 @@ impl Css {
     pub async fn new(
         cfg: Arc<RtcBuild>,
         html_dir: Arc<PathBuf>,
-        attrs: LinkAttrs,
+        attrs: Attrs,
         id: usize,
     ) -> Result<Self> {
         // Build the path to the target asset.

--- a/src/pipelines/html.rs
+++ b/src/pipelines/html.rs
@@ -15,8 +15,7 @@ use crate::config::RtcBuild;
 use crate::hooks::{spawn_hooks, wait_hooks};
 use crate::pipelines::rust::RustApp;
 use crate::pipelines::{
-    LinkAttrs, PipelineStage, TrunkAsset, TrunkAssetPipelineOutput, TrunkAssetReference, ATTR_SRC,
-    TRUNK_ID,
+    Attrs, PipelineStage, TrunkAsset, TrunkAssetPipelineOutput, TrunkAssetReference, TRUNK_ID,
 };
 
 const PUBLIC_URL_MARKER_ATTR: &str = "data-trunk-public-url";
@@ -95,7 +94,7 @@ impl HtmlPipeline {
                     let attrs = link
                         .attrs()
                         .into_iter()
-                        .fold(LinkAttrs::new(), |mut acc, attr| {
+                        .fold(Attrs::new(), |mut acc, attr| {
                             acc.insert(
                                 attr.name.local.as_ref().to_string(),
                                 attr.value.to_string(),
@@ -106,13 +105,17 @@ impl HtmlPipeline {
                     Some(TrunkAssetReference::Link(attrs))
                 }
                 Some("script") => {
-                    // Retrieve the src attribute.
-                    let src = link
+                    let attrs = link
                         .attrs()
                         .into_iter()
-                        .find(|attr| attr.name.local.as_ref() == ATTR_SRC)
-                        .map(|attr| attr.value.to_string());
-                    Some(TrunkAssetReference::Script(src))
+                        .fold(Attrs::new(), |mut acc, attr| {
+                            acc.insert(
+                                attr.name.local.as_ref().to_string(),
+                                attr.value.to_string(),
+                            );
+                            acc
+                        });
+                    Some(TrunkAssetReference::Script(attrs))
                 }
                 _ => None,
             };

--- a/src/pipelines/icon.rs
+++ b/src/pipelines/icon.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result};
 use nipper::Document;
 use tokio::task::JoinHandle;
 
-use super::{AssetFile, LinkAttrs, TrunkAssetPipelineOutput, ATTR_HREF};
+use super::{AssetFile, Attrs, TrunkAssetPipelineOutput, ATTR_HREF};
 use crate::config::RtcBuild;
 
 /// An Icon asset pipeline.
@@ -26,7 +26,7 @@ impl Icon {
     pub async fn new(
         cfg: Arc<RtcBuild>,
         html_dir: Arc<PathBuf>,
-        attrs: LinkAttrs,
+        attrs: Attrs,
         id: usize,
     ) -> Result<Self> {
         // Build the path to the target asset.

--- a/src/pipelines/inline.rs
+++ b/src/pipelines/inline.rs
@@ -8,7 +8,7 @@ use anyhow::{bail, Context, Result};
 use nipper::Document;
 use tokio::task::JoinHandle;
 
-use super::{AssetFile, LinkAttrs, TrunkAssetPipelineOutput, ATTR_HREF, ATTR_TYPE};
+use super::{AssetFile, Attrs, TrunkAssetPipelineOutput, ATTR_HREF, ATTR_TYPE};
 
 /// An Inline asset pipeline.
 pub struct Inline {
@@ -24,7 +24,7 @@ pub struct Inline {
 impl Inline {
     pub const TYPE_INLINE: &'static str = "inline";
 
-    pub async fn new(html_dir: Arc<PathBuf>, attrs: LinkAttrs, id: usize) -> Result<Self> {
+    pub async fn new(html_dir: Arc<PathBuf>, attrs: Attrs, id: usize) -> Result<Self> {
         let href_attr = attrs.get(ATTR_HREF).context(
             r#"required attr `href` missing for <link data-trunk rel="inline" .../> element"#,
         )?;

--- a/src/pipelines/js.rs
+++ b/src/pipelines/js.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result};
 use nipper::Document;
 use tokio::task::JoinHandle;
 
-use super::{AssetFile, TrunkAssetPipelineOutput};
+use super::{AssetFile, Attrs, TrunkAssetPipelineOutput, ATTR_SRC};
 use crate::config::RtcBuild;
 
 /// A JS asset pipeline.
@@ -18,22 +18,35 @@ pub struct Js {
     cfg: Arc<RtcBuild>,
     /// The asset file being processed.
     asset: AssetFile,
+    /// The attributes to be placed on the output script tag.
+    attrs: Attrs,
 }
 
 impl Js {
     pub async fn new(
         cfg: Arc<RtcBuild>,
         html_dir: Arc<PathBuf>,
-        src: Option<String>,
+        attrs: Attrs,
         id: usize,
     ) -> Result<Self> {
         // Build the path to the target asset.
-        let src_attr =
-            src.context(r#"required attr `src` missing for <script data-trunk .../> element"#)?;
+        let src_attr = attrs
+            .get(ATTR_SRC)
+            .context(r#"required attr `src` missing for <script data-trunk .../> element"#)?;
         let mut path = PathBuf::new();
         path.extend(src_attr.split('/'));
         let asset = AssetFile::new(&html_dir, path).await?;
-        Ok(Self { id, cfg, asset })
+        // Remove src and data-trunk from attributes.
+        let attrs = attrs
+            .into_iter()
+            .filter(|(x, _)| *x != "src" && !x.starts_with("data-trunk"))
+            .collect();
+        Ok(Self {
+            id,
+            cfg,
+            asset,
+            attrs,
+        })
     }
 
     /// Spawn the pipeline for this asset type.
@@ -52,11 +65,22 @@ impl Js {
             .copy(&self.cfg.staging_dist, self.cfg.filehash)
             .await?;
         tracing::info!(path = ?rel_path, "finished copying & hashing js");
+        let attrs = Self::attrs_to_string(self.attrs);
         Ok(TrunkAssetPipelineOutput::Js(JsOutput {
             cfg: self.cfg.clone(),
             id: self.id,
             file,
+            attrs,
         }))
+    }
+
+    /// Convert attributes to a string, to be used in JsOutput.
+    fn attrs_to_string(attrs: Attrs) -> String {
+        attrs
+            .into_iter()
+            .map(|(k, v)| format!("{k}=\"{v}\""))
+            .collect::<Vec<_>>()
+            .join(" ")
     }
 }
 
@@ -68,13 +92,16 @@ pub struct JsOutput {
     pub id: usize,
     /// Name of the finalized output file.
     pub file: String,
+    /// The attributes to be added to the script tag.
+    pub attrs: String,
 }
 
 impl JsOutput {
     pub async fn finalize(self, dom: &mut Document) -> Result<()> {
         dom.select(&super::trunk_script_id_selector(self.id))
             .replace_with_html(format!(
-                r#"<script src="{base}{file}"/>"#,
+                r#"<script {attrs} src="{base}{file}"/>"#,
+                attrs = self.attrs,
                 base = &self.cfg.public_url,
                 file = self.file
             ));

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -41,12 +41,12 @@ const SNIPPETS_DIR: &str = "snippets";
 const TRUNK_ID: &str = "data-trunk-id";
 
 /// A mapping of all attrs associated with a specific `<link data-trunk .../>` element.
-pub type LinkAttrs = HashMap<String, String>;
+pub type Attrs = HashMap<String, String>;
 
 /// A reference to a trunk asset.
 pub enum TrunkAssetReference {
-    Link(LinkAttrs),
-    Script(Option<String>),
+    Link(Attrs),
+    Script(Attrs),
 }
 
 /// A model of all of the supported Trunk asset links expressed in the source HTML as
@@ -104,8 +104,8 @@ impl TrunkAsset {
                     ),
                 })
             }
-            TrunkAssetReference::Script(src) => {
-                Ok(Self::Js(Js::new(cfg, html_dir, src, id).await?))
+            TrunkAssetReference::Script(attrs) => {
+                Ok(Self::Js(Js::new(cfg, html_dir, attrs, id).await?))
             }
         }
     }

--- a/src/pipelines/rust.rs
+++ b/src/pipelines/rust.rs
@@ -16,7 +16,7 @@ use tokio::process::Command;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
-use super::{LinkAttrs, TrunkAssetPipelineOutput, ATTR_HREF, SNIPPETS_DIR};
+use super::{Attrs, TrunkAssetPipelineOutput, ATTR_HREF, SNIPPETS_DIR};
 use crate::common::{self, copy_dir_recursive, path_exists};
 use crate::config::{CargoMetadata, ConfigOptsTools, Features, RtcBuild};
 use crate::tools::{self, Application};
@@ -90,7 +90,7 @@ impl RustApp {
         cfg: Arc<RtcBuild>,
         html_dir: Arc<PathBuf>,
         ignore_chan: Option<mpsc::Sender<PathBuf>>,
-        attrs: LinkAttrs,
+        attrs: Attrs,
         id: usize,
     ) -> Result<Self> {
         // Build the path to the target asset.

--- a/src/pipelines/sass.rs
+++ b/src/pipelines/sass.rs
@@ -8,7 +8,7 @@ use nipper::Document;
 use tokio::fs;
 use tokio::task::JoinHandle;
 
-use super::{AssetFile, LinkAttrs, TrunkAssetPipelineOutput, ATTR_HREF, ATTR_INLINE};
+use super::{AssetFile, Attrs, TrunkAssetPipelineOutput, ATTR_HREF, ATTR_INLINE};
 use crate::common;
 use crate::config::RtcBuild;
 use crate::tools::{self, Application};
@@ -32,7 +32,7 @@ impl Sass {
     pub async fn new(
         cfg: Arc<RtcBuild>,
         html_dir: Arc<PathBuf>,
-        attrs: LinkAttrs,
+        attrs: Attrs,
         id: usize,
     ) -> Result<Self> {
         // Build the path to the target asset.


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [ ] Updated `site` content with pertinent info (may not always apply).
- [X] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.

---

I didn't update the CHANGELOG, as the script functionality hasn't been released and I don't believe this is worth adding. If you disagree, let me know and I can update it. :)

This solves #429, where an input index.html that contains:
```html
<script data-trunk data-manual async defer src="assets/prism.js"></script>
```

will now be saved in the output index.html as:
```html
<script data-manual="" defer="" async="" src="/prism-f9cf5f0b49dcc1e.js"></script>
```

It appears that whatever is outputting the HTML automatically adds the `=""`, even when there was no value originally, but that's okay because it's still valid.

In `attrs_to_string`, I was originally outputting just the key when the value was empty, but `=""` was still being added, so I shortened the function by outputting `=""` anyways.