### PR TITLE
Update CI to no longer deny linter warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-targets -- -D warnings
+          args: --all-targets
 
       - name: Setup | Toolchain (rustfmt)
         uses: actions-rs/toolchain@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 - Updated gloo-worker example to use gloo-worker crate v2.1.
 - Our website (trunkrs.dev) now only updates on new releases.
 - Additional attributes are now passed through script tags (fixes #429)
+- Updated internal http stack to axum v0.6.0.
 ### fixed
 - Nested WS proxies - if `backend=ws://localhost:8000/ws` is set, queries for `ws://localhost:8080/ws/entityX` will be linked with `ws://localhost:8000/ws/entityX`
 - Updated all dependencies in both Trunk and its examples, to fix currently open security advisories for old dependencies.

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,12 +1,12 @@
 use std::sync::Arc;
 
 use anyhow::Context;
-use axum::RequestExt;
 use axum::body::Body;
 use axum::extract::ws::{Message as MsgAxm, WebSocket, WebSocketUpgrade};
 use axum::extract::State;
 use axum::http::{Request, Response, Uri};
 use axum::routing::{any, get, Router};
+use axum::RequestExt;
 use futures_util::sink::SinkExt;
 use futures_util::stream::StreamExt;
 use reqwest::header::HeaderValue;
@@ -76,7 +76,7 @@ impl ProxyHandlerHttp {
             self.path(),
             any(Self::proxy_http_request)
                 .layer(TraceLayer::new_for_http())
-                .with_state(self.clone())
+                .with_state(self.clone()),
         )
     }
 
@@ -89,7 +89,10 @@ impl ProxyHandlerHttp {
 
     /// Proxy the given request to the target backend.
     #[tracing::instrument(level = "debug", skip(state, req))]
-    async fn proxy_http_request(State(state): State<Arc<Self>>, req: Request<Body>) -> ServerResult<Response<Body>> {
+    async fn proxy_http_request(
+        State(state): State<Arc<Self>>,
+        req: Request<Body>,
+    ) -> ServerResult<Response<Body>> {
         // Construct the outbound URI & build a new request to be sent to the proxy backend.
         let outbound_uri = make_outbound_uri(&state.backend, req.uri())?;
         let mut outbound_req = state

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -263,7 +263,7 @@ async fn find_system(app: Application, version: Option<&str>) -> Option<(PathBuf
         Ok((path, system_version)) => version
             .map(|v| v == system_version)
             .unwrap_or(true)
-            .then(|| (path, system_version)),
+            .then_some((path, system_version)),
         Err(e) => {
             tracing::debug!("system version not found for {}: {}", app.name(), e);
             None


### PR DESCRIPTION
This can be a bit of a difficulty for folks opening PRs and then the linter complains about completely unrelated code and denies their PR.

Instead, we continue to warn about these issues, but we do not block CI.