### PR TITLE
Support relative public URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 - Our website (trunkrs.dev) now only updates on new releases.
 - Additional attributes are now passed through script tags (fixes #429)
 - Updated internal http stack to axum v0.6.0.
+- The `public-url` setting now supports relative paths.
 ### fixed
 - Nested WS proxies - if `backend=ws://localhost:8000/ws` is set, queries for `ws://localhost:8080/ws/entityX` will be linked with `ws://localhost:8000/ws/entityX`
 - Updated all dependencies in both Trunk and its examples, to fix currently open security advisories for old dependencies.

--- a/src/common.rs
+++ b/src/common.rs
@@ -23,9 +23,7 @@ static CWD: Lazy<PathBuf> =
 
 /// Ensure the given value for `--public-url` is formatted correctly.
 pub fn parse_public_url(val: &str) -> String {
-    let prefix = if !val.starts_with('/') { "/" } else { "" };
-    let suffix = if !val.ends_with('/') { "/" } else { "" };
-    format!("{}{}{}", prefix, val, suffix)
+    format!("{}/", val.trim_end_matches('/'))
 }
 
 /// A utility function to recursively copy a directory.

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,5 @@
 //! Common functionality and types.
 
-use std::convert::Infallible;
 use std::ffi::OsStr;
 use std::fmt::Debug;
 use std::fs::Metadata;
@@ -23,8 +22,8 @@ static CWD: Lazy<PathBuf> =
     Lazy::new(|| std::env::current_dir().expect("error getting current dir"));
 
 /// Ensure the given value for `--public-url` is formatted correctly.
-pub fn parse_public_url(val: &str) -> String {
-    format!("{}/", val.trim_end_matches('/'))
+pub fn parse_public_url(val: &str) -> Result<String> {
+    Ok(format!("{}/", val.trim_end_matches('/')))
 }
 
 /// A utility function to recursively copy a directory.


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [x] Updated README.md with pertinent info (may not always apply).
- [x] Updated `site` content with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.

---

As longly requested in #361, this should make it possible to use relative URLs for the `public-url` setting, while not breaking the Axum route at the same time.

The adjustment for the public URL is now a bit more relaxed, so that it only corrects trailing slashes and allows for various relative paths in the front. Then, later on the Axum router uses a fake `Url` as base to join against the given public URL. This will resolve it into an absolute URL that should work as route path.

- `/` -> `/` -> axum `/`
- `./` -> `./` -> axum `/`
- `../` -> `../` -> axum `/`
- `test/../a///` -> `test/../a/` -> axum `/a`

The prefixing of the public URL with a `/`, is not needed anymore, unless there is some case I might have not thought of?
