### PR TITLE
Add svg to Inline ContentType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 - Added `data-target-path` to `copy-dir`.
 - Allow processing `<script>` tags with the asset pipeline.
 - Added `data-loader-shim` to workers to create shim script.
+- Added support for `svg` files when using `rel="inline"` 
 ### changed
 - Updated gloo-worker example to use gloo-worker crate v2.1.
 - Our website (trunkrs.dev) now only updates on new releases.

--- a/site/content/assets.md
+++ b/site/content/assets.md
@@ -46,7 +46,7 @@ This will typically look like: `<link data-trunk rel="{type}" href="{path}" ..ot
 
 ## inline
 ✅ `rel="inline"`: Trunk will inline the content of the file specified in the `href` attribute into `index.html`. This content is copied exactly, no hashing is performed.
-  - `type`: (optional) either `html`, `css`, or `js`. If not present, the type is inferred by the file extension. `css` is wrapped in `style` tags, while
+  - `type`: (optional) either `html`, `svg`, `css`, or `js`. If not present, the type is inferred by the file extension. `css` is wrapped in `style` tags, while
   `js` is wrapped in `script` tags.
 
 ## copy-file

--- a/src/pipelines/inline.rs
+++ b/src/pipelines/inline.rs
@@ -69,6 +69,8 @@ impl Inline {
 pub enum ContentType {
     /// Html is just pasted into `index.html` as is.
     Html,
+    /// Svg is just pasted into `index.html` as is.
+    Svg,
     /// CSS is wrapped into `style` tags.
     Css,
     /// JS is wrapped into `script` tags.
@@ -99,6 +101,7 @@ impl FromStr for ContentType {
             "html" => Ok(Self::Html),
             "css" => Ok(Self::Css),
             "js" => Ok(Self::Js),
+            "svg" => Ok(Self::Svg),
             s => bail!(
                 r#"unknown `type="{}"` value for <link data-trunk rel="inline" .../> attr; please ensure the value is lowercase and is a supported content type"#,
                 s
@@ -120,7 +123,7 @@ pub struct InlineOutput {
 impl InlineOutput {
     pub async fn finalize(self, dom: &mut Document) -> Result<()> {
         let html = match self.content_type {
-            ContentType::Html => self.content,
+            ContentType::Html | ContentType::Svg => self.content,
             ContentType::Css => format!(r#"<style type="text/css">{}</style>"#, self.content),
             ContentType::Js => format!(r#"<script>{}</script>"#, self.content),
         };


### PR DESCRIPTION
Hey!
Thanks you everyone who've worked on trunk, it's a really nice little tool and i use it for most of my small little projects. There was no mention of the option to inline svg anywhere and since it's such a small little update i just thought id make the pr. :see_no_evil: 

**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [x] Updated `site` content with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
