### PR TITLE
Prevent buildup of change events, debouncing while busy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 - Features passed to trunk build are now passed to cargo build (unless overridden by attributes in the HTML file)
 - Fix [trunk/issues/330](https://github.com/thedodd/trunk/issues/330), to properly handle proxy endpoint with and without a slash at the end.
 - Fix [trunk/issues/475](https://github.com/thedodd/trunk/issues/475) indeterminate trunk behaviour when the project defines several binary crates and index.html has no `<link rel="rust" data-bin=...>`
+- Prevent buildup of change events and "endless" build loops
 
 ## 0.16.0
 ### added

--- a/src/cmd/watch.rs
+++ b/src/cmd/watch.rs
@@ -22,9 +22,9 @@ impl Watch {
     pub async fn run(self, config: Option<PathBuf>) -> Result<()> {
         let (shutdown_tx, _shutdown_rx) = broadcast::channel(1);
         let cfg = ConfigOpts::rtc_watch(self.build, self.watch, config)?;
-        let mut system = WatchSystem::new(cfg, shutdown_tx.clone(), None).await?;
+        let system = WatchSystem::new(cfg, shutdown_tx.clone(), None).await?;
 
-        system.build().await.ok();
+        system.trigger_build();
         let system_handle = tokio::spawn(system.run());
         tokio::signal::ctrl_c()
             .await

--- a/src/cmd/watch.rs
+++ b/src/cmd/watch.rs
@@ -24,7 +24,7 @@ impl Watch {
         let cfg = ConfigOpts::rtc_watch(self.build, self.watch, config)?;
         let system = WatchSystem::new(cfg, shutdown_tx.clone(), None).await?;
 
-        system.trigger_build();
+        system.trigger_build().await;
         let system_handle = tokio::spawn(system.run());
         tokio::signal::ctrl_c()
             .await

--- a/src/debouncer.rs
+++ b/src/debouncer.rs
@@ -1,6 +1,7 @@
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+
 use tokio::sync::{Mutex, Notify};
 
 /// Debounces events as long as it is busy.

--- a/src/debouncer.rs
+++ b/src/debouncer.rs
@@ -1,0 +1,74 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use tokio::sync::Notify;
+
+/// Debounces events as long as it is busy.
+///
+/// Instead of using a fixed time period to debounce events, it debounces events
+/// as long as it is busy working on an event.
+///
+/// The idea is that a producer can push events to the debouncer, which take some time processing.
+/// While processing, only the most recent event will be recorded, and executed after the
+/// previous event finished.
+///
+/// It is intended for scenarios where it is not important to execute a task for all events, but
+/// (ideally) as soon as possible, at least once after an event was published, but not process
+/// for events that are obsolete due to succeeding events.
+pub struct BusyDebouncer<T> {
+    notify: Arc<Notify>,
+    data: Arc<Mutex<Option<T>>>,
+}
+
+impl<T> BusyDebouncer<T> {
+    pub fn new<C, F>(context: C, handler: F) -> Self
+    where
+        C: Send + 'static,
+        T: Send + Sync + 'static,
+        for<'a> F: Fn(&'a mut C, T) -> Pin<Box<dyn Future<Output = ()> + Send + Sync + 'a>>
+            + Send
+            + Sync
+            + 'static,
+    {
+        let notify = Arc::new(Notify::new());
+        let data = Arc::new(Mutex::new(None));
+
+        {
+            let notify = notify.clone();
+            let data = data.clone();
+            tokio::spawn(async move {
+                let mut context = context;
+                loop {
+                    notify.notified().await;
+                    let next = data.lock().unwrap().take();
+                    match next {
+                        Some(event) => {
+                            handler(&mut context, event).await;
+                        }
+                        None => break,
+                    }
+                }
+            });
+        }
+
+        Self { notify, data }
+    }
+
+    /// Push a new task to the debouncer.
+    ///
+    /// This call will return immediately, and might spawn the event now, at a later time, or never.
+    pub fn push(&self, event: T) {
+        self.send(Some(event));
+    }
+
+    fn send(&self, msg: Option<T>) {
+        *self.data.lock().unwrap() = msg;
+        self.notify.notify_one();
+    }
+}
+
+impl<T> Drop for BusyDebouncer<T> {
+    fn drop(&mut self) {
+        self.send(None);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod build;
 mod cmd;
 mod common;
 mod config;
+mod debouncer;
 mod hooks;
 mod pipelines;
 mod proxy;

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -60,7 +60,7 @@ impl ServeSystem {
     pub async fn run(self) -> Result<()> {
         // Perform an initial build
         let mut build_done_rx = self.build_done_chan.subscribe();
-        self.watch.trigger_build();
+        self.watch.trigger_build().await;
         let _build_res = build_done_rx.recv().await; // TODO: only open after a successful build.
         drop(build_done_rx);
 

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -53,8 +53,9 @@ impl WatchSystem {
             Box::pin(async move {
                 let _res = build.build().await;
 
-                // TODO/NOTE: in the future, we will want to be able to pass along error info and other
-                // diagnostics info over the socket for use in an error overlay or console logging.
+                // TODO/NOTE: in the future, we will want to be able to pass along error info and
+                // other diagnostics info over the socket for use in an error overlay or console
+                // logging.
                 if let Some(tx) = build_done_tx.as_mut() {
                     let _ = tx.send(());
                 }

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -73,8 +73,8 @@ impl WatchSystem {
 
     /// Run a build.
     #[tracing::instrument(level = "trace", skip(self))]
-    pub fn trigger_build(&self) {
-        self.debouncer.push(());
+    pub async fn trigger_build(&self) {
+        self.debouncer.push(()).await;
     }
 
     /// Run the watch system, responding to events and triggering builds.
@@ -132,7 +132,7 @@ impl WatchSystem {
 
         tracing::info!("change detected in {:?}", ev_path);
 
-        self.trigger_build();
+        self.trigger_build().await;
     }
 
     fn update_ignore_list(&mut self, arg_path: PathBuf) {


### PR DESCRIPTION
Changes from the file system already get debounced in a 1 second window. However, still each change that gets reported, will trigger a build. All changes happening during the build will get buffered and sequentially be executed.

Depending on the length of the build, and the input from the user during this time, this can lead to a huge amount of changes, leading to a buildup that makes it look like trunk is "continuously" rebuilding.

This change debounces change event while the build is active. It will record the request for a new build, and notify the build loop. Only when the build loop has started can another request be recorded.

This results in a build starting as soon as possible when the first events emitted and ensures at most one more run after the build has finishes. No additional requests will be queued.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [x] Updated README.md with pertinent info (may not always apply).
- [x] Updated `site` content with pertinent info (may not always apply).
- [ ] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
