### PR TITLE
Add data-wasm-opt-keep-names to Rust asset pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 - Added `data-loader-shim` to workers to create shim script.
 - Added tailwindcss support via `rel="tailwind-css"`.
 - Added support for `svg` files when using `rel="inline"`
+- Added `data-wasm-opt-keep-names` to Rust pipeline. Used to specify `-g` flag to `wasm-opt`
 
 ### changed
 - Updated gloo-worker example to use gloo-worker crate v2.1.

--- a/site/content/assets.md
+++ b/site/content/assets.md
@@ -26,6 +26,7 @@ This will typically look like: `<link data-trunk rel="{type}" href="{path}" ..ot
   - `data-cargo-all-features`: (optional) Enables all Cargo features.
     - Neither compatible with `data-cargo-features` nor `data-cargo-no-default-features`.
   - `data-wasm-opt`: (optional) run wasm-opt with the set optimization level. The possible values are `0`, `1`, `2`, `3`, `4`, `s`, `z` or an _empty value_ for wasm-opt's default. Set this option to `0` to disable wasm-opt explicitly. The values `1-4` are increasingly stronger optimization levels for speed. `s` and `z` (z means more optimization) optimize for binary size instead. Only used in `--release` mode.
+  - `data-wasm-opt-keep-names`: (optional) add a `-g` flag to wasm-opt, which keeps debug information, including function names.
   - `data-keep-debug`: (optional) instruct `wasm-bindgen` to preserve debug info in the final WASM output, even for `--release` mode. This may conflict with the use of wasm-opt, so to be sure, it is recommended to set `data-wasm-opt="0"` when using this option.
   - `data-no-demangle`: (optional) instruct `wasm-bindgen` to not demangle Rust symbol names.
   - `data-reference-types`: (optional) instruct `wasm-bindgen` to enable [reference types](https://rustwasm.github.io/docs/wasm-bindgen/reference/reference-types.html).


### PR DESCRIPTION
## data-wasm-opt-keep-names

This adds a new option to the Rust pipeline which gives the user the ability to pass `-g` to wasm-opt tool.

I have had this version locally for a long time. I used it to keep function names in the wasm so I can analyze performance in Chrome Developer Tools. Without function names this is essentially impossible. With function names it is still difficult because it is post-optimization, but much better to have them than not.

This option defaults `false`, and the user must specify a value such as `true` to enable it.

**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [x] Updated README.md with pertinent info (may not always apply).
- [x] Updated `site` content with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
