### PR TITLE
Test `CopyDir` and assert whether `data-target-path` is used

### DIFF
--- a/src/pipelines/copy_dir_test.rs
+++ b/src/pipelines/copy_dir_test.rs
@@ -34,8 +34,8 @@ async fn err_new_missing_href() -> Result<()> {
     // Assert.
     anyhow::ensure!(
         res.is_err(),
-        "unexpected success while constructing CopyDir pipeline, expected error on missing \
-         `href` attr"
+        "unexpected success while constructing CopyDir pipeline, expected error on missing `href` \
+         attr"
     );
 
     Ok(())

--- a/src/pipelines/copy_dir_test.rs
+++ b/src/pipelines/copy_dir_test.rs
@@ -1,0 +1,101 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+
+use crate::config::RtcBuild;
+use crate::pipelines::copy_dir::*;
+use crate::pipelines::ATTR_HREF;
+
+/// A fixture for setting up basic test config.
+async fn setup_test_config() -> Result<(tempfile::TempDir, Arc<RtcBuild>, PathBuf)> {
+    let tmpdir = tempfile::tempdir().context("error building tempdir for test")?;
+    let cfg = Arc::new(RtcBuild::new_test(tmpdir.path()).await?);
+    let asset_dir = tmpdir.path().join("test_dir");
+    tokio::fs::create_dir(&asset_dir)
+        .await
+        .context("error creating test dir")?;
+    let asset_file = asset_dir.join("test_file");
+    tokio::fs::write(&asset_file, b"abc123")
+        .await
+        .context("error writing test file contents")?;
+    Ok((tmpdir, cfg, asset_dir))
+}
+
+#[tokio::test]
+async fn err_new_missing_href() -> Result<()> {
+    // Assemble.
+    let (tmpdir, cfg, _) = setup_test_config().await?;
+
+    // Action.
+    let res = CopyDir::new(cfg, Arc::new(tmpdir.into_path()), Default::default(), 0).await;
+
+    // Assert.
+    anyhow::ensure!(
+        res.is_err(),
+        "unexpected success while constructing CopyDir pipeline, expected error on missing \
+         `href` attr"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn ok_new() -> Result<()> {
+    // Assemble.
+    let (tmpdir, cfg, _) = setup_test_config().await?;
+    let mut attrs = HashMap::new();
+    attrs.insert(ATTR_HREF.into(), "test_dir".into());
+
+    // Action.
+    let res = CopyDir::new(cfg, Arc::new(tmpdir.into_path()), attrs, 0).await;
+
+    // Assert.
+    anyhow::ensure!(
+        res.is_ok(),
+        "unexpected failure while constructing CopyDir pipeline"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn ok_run_basic_copy() -> Result<()> {
+    // Assemble.
+    let (tmpdir, cfg, asset_dir) = setup_test_config().await?;
+    let copy_location_dir = cfg.staging_dist.join("test_dir");
+    let mut attrs = HashMap::new();
+    attrs.insert(ATTR_HREF.into(), "test_dir".into());
+    let cmd = CopyDir::new(cfg, Arc::new(tmpdir.into_path()), attrs, 0)
+        .await
+        .context("error constructing CopyDir pipeline")?;
+
+    // Action.
+    let _out = cmd
+        .spawn()
+        .await
+        .context("unexpected task join error from pipeline")?
+        .context("unexpected pipeline error")?;
+
+    // Assert.
+    let orig_file = tokio::fs::read_to_string(asset_dir.join("test_file"))
+        .await
+        .context("error reading original file")?;
+    let copied_file = tokio::fs::read_to_string(copy_location_dir.join("test_file"))
+        .await
+        .context("error reading copied file")?;
+    anyhow::ensure!(
+        copy_location_dir.is_dir(),
+        "expected '{}' to be a directory",
+        copy_location_dir.display(),
+    );
+    anyhow::ensure!(
+        orig_file == copied_file,
+        "unexpected content after copy, expected '{}' == '{}'",
+        orig_file,
+        copied_file
+    );
+
+    Ok(())
+}

--- a/src/pipelines/copy_dir_test.rs
+++ b/src/pipelines/copy_dir_test.rs
@@ -99,3 +99,44 @@ async fn ok_run_basic_copy() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn ok_run_target_path_copy() -> Result<()> {
+    // Assemble.
+    let (tmpdir, cfg, asset_dir) = setup_test_config().await?;
+    let copy_location_dir = cfg.staging_dist.join("not-test_dir");
+    let mut attrs = HashMap::new();
+    attrs.insert(ATTR_HREF.into(), "test_dir".into());
+    attrs.insert("data-target-path".into(), "not-test_dir".into());
+    let cmd = CopyDir::new(cfg, Arc::new(tmpdir.into_path()), attrs, 0)
+        .await
+        .context("error constructing CopyDir pipeline")?;
+
+    // Action.
+    let _out = cmd
+        .spawn()
+        .await
+        .context("unexpected task join error from pipeline")?
+        .context("unexpected pipeline error")?;
+
+    // Assert.
+    let orig_file = tokio::fs::read_to_string(asset_dir.join("test_file"))
+        .await
+        .context("error reading original file")?;
+    let copied_file = tokio::fs::read_to_string(copy_location_dir.join("test_file"))
+        .await
+        .context("error reading copied file")?;
+    anyhow::ensure!(
+        copy_location_dir.is_dir(),
+        "expected '{}' to be a directory",
+        copy_location_dir.display(),
+    );
+    anyhow::ensure!(
+        orig_file == copied_file,
+        "unexpected content after copy, expected '{}' == '{}'",
+        orig_file,
+        copied_file
+    );
+
+    Ok(())
+}

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -1,4 +1,6 @@
 mod copy_dir;
+#[cfg(test)]
+mod copy_dir_test;
 mod copy_file;
 #[cfg(test)]
 mod copy_file_test;


### PR DESCRIPTION
Test `CopyDir` pipeline and assert whether `data-target-path` is used correctly when specified.

I had the same issue as #524, and while I figured it was stemming from a regression, I just realized it was because my trunk install was from before [`fbb0be`](https://github.com/thedodd/trunk/commit/fbb0be88d3b74a720a3c51380662fc46f19eab97) had landed and the `data-target-path` attr was simply ignored.

Regardless, I figured it would help to test if it was actually being used as intended so I loosely copied `copy_file_test.rs` to also test if dirs were created and contents copied.

Also do any of these points apply? It's just a test case after all.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [ ] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [ ] Updated `site` content with pertinent info (may not always apply).
- [ ] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
