### PR TITLE
allow sass source-maps in dev envs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 - Updated CLI argument parser to clap v0.4.
 - Reduce error to warning when processing a project without Cargo.toml and no `<link rel="rust"/>` (fixes #487)
 - Add wasm-bindgen URLs for all supported architectures
+- Enable SASS/SCSS sitemaps on dev environments. Will remain disabled on `--release`
 
 ### fixed
 - Nested WS proxies - if `backend=ws://localhost:8000/ws` is set, queries for `ws://localhost:8080/ws/entityX` will be linked with `ws://localhost:8000/ws/entityX`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 ## Unreleased
 
+- Enable SASS/SCSS sitemaps on dev environments. Will remain disabled on `--release`
+
 ## 0.17.2
 ### fixed
 - Add missing `tools.tailwindcss` setting to configure the version of the Tailwindcss CLI to download.
@@ -38,7 +40,6 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 - Updated CLI argument parser to clap v0.4.
 - Reduce error to warning when processing a project without Cargo.toml and no `<link rel="rust"/>` (fixes #487)
 - Add wasm-bindgen URLs for all supported architectures
-- Enable SASS/SCSS sitemaps on dev environments. Will remain disabled on `--release`
 
 ### fixed
 - Nested WS proxies - if `backend=ws://localhost:8000/ws` is set, queries for `ws://localhost:8080/ws/entityX` will be linked with `ws://localhost:8000/ws/entityX`

--- a/src/pipelines/sass.rs
+++ b/src/pipelines/sass.rs
@@ -65,17 +65,17 @@ impl Sass {
         let sass = tools::get(Application::Sass, version).await?;
 
         // Compile the target SASS/SCSS file.
-        let style = if self.cfg.release {
-            "compressed"
+        let (style, source_map) = if self.cfg.release {
+            ("compressed", "--no-source-map")
         } else {
-            "expanded"
+            ("expanded", "--embed-source-map")
         };
         let path_str = dunce::simplified(&self.asset.path).display().to_string();
         let file_name = format!("{}.css", &self.asset.file_stem.to_string_lossy());
         let file_path = dunce::simplified(&self.cfg.staging_dist.join(&file_name))
             .display()
             .to_string();
-        let args = &["--no-source-map", "-s", style, &path_str, &file_path];
+        let args = &[source_map, "-s", style, &path_str, &file_path];
 
         let rel_path = crate::common::strip_prefix(&self.asset.path);
         tracing::info!(path = ?rel_path, "compiling sass/scss");


### PR DESCRIPTION
Currently SASS/SCSS source-maps are disabled by default #528. It would be nice to have source-maps in development to easily debug css.

This function was probably disabled to keep things simple. I noticed that the choice generate compressed/expand css was neatly defined in the module i.e depending if the configuration was in release mode or not. https://github.com/thedodd/trunk/blob/7769a17e517391b3b4077c21062725aa1600346d/src/pipelines/sass.rs#L68-L71

 Using the same conditional, source-maps could be enabled in dev mode. Unless I missed something, this change wouldn't need an extra write to the filesystem since the [--embed-source-maps](https://sass-lang.com/documentation/cli/dart-sass#embed-source-map) sass option appends the source-maps at the end of the css file.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [ ] Updated `site` content with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
