### PR TITLE
pass through any other HTML attributes given to a <link rel="stylesheet">

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This changelog follows the patterns described here: https://keepachangelog.com/e
 Subheadings to categorize changes are `added, changed, deprecated, removed, fixed, security`.
 
 ## Unreleased
+### added
+- Pass through any additional HTML attributes on CSS assets. For instance, the 
+  disabled attribute on a linked stylesheet: `<link rel="css" disabled ... />`.
 
 ## 0.17.2
 ### fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,6 +939,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "htmlescape"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
+
+[[package]]
 name = "http"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2758,6 +2764,7 @@ dependencies = [
  "flate2",
  "fs_extra",
  "futures-util",
+ "htmlescape",
  "local-ip-address",
  "nipper",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ envy = "0.4"
 flate2 = "1"
 fs_extra = "1"
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
+htmlescape = "0.3.1"
 local-ip-address = "0.5.1"
 nipper = "0.1"
 notify = "4"


### PR DESCRIPTION
Use case here is stuff like:
- Using `<link rel="stylesheet" blocking="render" />`
- Using `<link rel="stylesheet" disabled />`
- Using `<link rel="stylesheet" integrity="hash..." />`
- Using `<link rel="stylesheet" crossorigin="..." />`
- Anything else on the [long list of useful attributes the link element supports](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attributes)

Before, those attributes would just be left behind. Now they are passed through. There is a system in there for ignoring the ones that Trunk wants to control.

I haven't implemented this on any other asset types, but the AttrWriter is reusable. Also there is clearly the possibility to refactor the three nearly-identical-and-could-be-identical output types for css/sass/tailwind (which would also make it possible to inline a normal CSS file, not just sass/tailwind output), but I didn't do it to keep the review small.

I think it's great that Trunk uses an actual HTML file to configure assets. This just makes it live up to the potential of this pattern a little more.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [ ] Updated `site` content with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
