### PR TITLE
feat: allow trunk to be used as a build-time dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 ## Unreleased
 
+- Allow trunk to be used as a build-time dependency by making it a library.
+
 ## 0.17.3
 ### added
 - Add `inject_scripts` option to build configuration to allow toggle of injecting the modulepreload and scripts rendered in the final html.

--- a/site/content/build_time.md
+++ b/site/content/build_time.md
@@ -1,0 +1,59 @@
++++
+title = "Build-time Dependency"
+description = "Using Trunk as a build-time dependency"
+weight = 4
++++
+
+You can also use Trunk as a build-time dependency. This is useful if you want to build your application and then bundle inside another Rust application. The built application can be bundled using [rust-embed](https://github.com/pyrossh/rust-embed) or similar and then served by a webserver or any other way.
+
+Here is an example:
+
+**Cargo.toml**
+
+```toml
+# ...
+
+[build-dependencies]
+trunk = "0.18.0"
+
+# ...
+```
+
+**build.rs**
+
+```rust
+use std::env;
+use std::path::Path;
+use trunk::{cmd::build::Build, config::ConfigOptsBuild};
+
+#[tokio::main]
+async fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=frontend");
+    Build{
+      build: ConfigOptsBuild {
+        release: true,
+        public_url: Some("/dist/".to_string()),
+        target: Some(Path::new(FRONTEND).join("index.html").to_path_buf()),
+        dist: Some(Path::new(env::var("OUT_DIR").unwrap().as_str()).join("frontend").to_path_buf()),
+        ..ConfigOptsBuild::default()
+      },
+    }.run(None).await.unwrap();
+}
+```
+
+**src/main.rs**
+
+```rust
+// ...
+use rust_embed::RustEmbed;
+
+#[derive(RustEmbed)]
+#[folder = "$OUT_DIR/frontend"]
+struct Asset;
+
+fn main() {
+    let index_html = Asset::get("index.html").unwrap();
+    println!("{}", String::from_utf8(index_html.to_vec()).unwrap());
+}
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,10 @@
+mod build;
+pub mod cmd;
+mod common;
+pub mod config;
+mod hooks;
+mod pipelines;
+mod proxy;
+mod serve;
+mod tools;
+mod watch;


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [X] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [X] Updated `site` content with pertinent info (may not always apply).
- [X] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.

Hi @thedodd, thanks for this great tool! 😄 

I was embedding a front-end app into a Rust application to be served by a web server recently and couldn't get it to work through `build.rs`.
So I added a `lib.rs` to export some of the internal functions of trunk to be able to do that in a similar manner to [cc](https://docs.rs/cc/latest/cc/):

```rust
fn main() {
    cc::Build::new()
        .file("src/foo.c")
        .define("FOO", Some("bar"))
        .include("src")
        .compile("foo");
}
```

I updated the `site` with an example, I can also create a separate example if that's needed.