### PR TITLE
Remove HTML glob in example tailwind.config.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This changelog follows the patterns described here: https://keepachangelog.com/e
 Subheadings to categorize changes are `added, changed, deprecated, removed, fixed, security`.
 
 ## Unreleased
+### changed
+- Remove HTML glob in tailwind.config.js
 
 ## 0.17.3
 ### added

--- a/examples/yew-tailwindcss/tailwind.config.js
+++ b/examples/yew-tailwindcss/tailwind.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   mode: "jit",
   content: {
-    files: ["src/**/*.rs", "**/*.html"],
+    files: ["src/**/*.rs", "index.html"],
   },
   darkMode: "media", // 'media' or 'class'
   theme: {


### PR DESCRIPTION
I copied this example for a project, but the `**/*.html` pattern was likely causing tailwind to scan the `target` directory making builds unreasonably slow.

**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [x] Updated README.md with pertinent info (may not always apply).
- [x] Updated `site` content with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
