### PR TITLE
Add --accept-invalid-certs option to set reqwest danger_accept_invalid_certs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 ## Unreleased
 ### changed
 - Remove HTML glob in tailwind.config.js
+- Add --accept-invalid-certs option to set reqwest danger_accept_invalid_certs
 
 ## 0.17.4
 ### added

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -43,6 +43,11 @@ pub struct ConfigOptsBuild {
     /// Whether to include hash values in the output file names [default: true]
     #[arg(long)]
     pub filehash: Option<bool>,
+    /// Enable reqwest danger_accept_invalid_certs [default: false]
+    #[arg(long)]
+    #[serde(default)]
+    pub accept_invalid_certs: bool,
+
     /// Optional pattern for the app loader script [default: None]
     ///
     /// Patterns should include the sequences `{base}`, `{wasm}`, and `{js}` in order to
@@ -300,6 +305,7 @@ impl ConfigOpts {
             no_default_features: cli.no_default_features,
             all_features: cli.all_features,
             features: cli.features,
+            accept_invalid_certs: cli.accept_invalid_certs,
             filehash: cli.filehash,
             inject_scripts: cli.inject_scripts,
             pattern_script: cli.pattern_script,

--- a/src/config/rt.rs
+++ b/src/config/rt.rs
@@ -39,6 +39,8 @@ pub struct RtcBuild {
     /// If `true`, then files being processed should be hashed and the hash should be
     /// appeneded to the file's name.
     pub filehash: bool,
+    /// If `true`, set reqwest danger_accept_invalid_certs(true)
+    pub accept_invalid_certs: bool,
     /// The directory where final build artifacts are placed after a successful build.
     pub final_dist: PathBuf,
     /// The directory used to stage build artifacts during an active build.
@@ -126,6 +128,7 @@ impl RtcBuild {
             release: opts.release,
             public_url: opts.public_url.unwrap_or_else(|| "/".into()),
             filehash: opts.filehash.unwrap_or(true),
+            accept_invalid_certs: opts.accept_invalid_certs,
             staging_dist,
             final_dist,
             cargo_features,
@@ -155,6 +158,7 @@ impl RtcBuild {
             release: false,
             public_url: "/".into(),
             filehash: true,
+            accept_invalid_certs: false,
             final_dist,
             staging_dist,
             cargo_features: Features::All,

--- a/src/pipelines/rust.rs
+++ b/src/pipelines/rust.rs
@@ -365,7 +365,12 @@ impl RustApp {
         };
 
         let version = find_wasm_bindgen_version(&self.cfg.tools, &self.manifest);
-        let wasm_bindgen = tools::get(Application::WasmBindgen, version.as_deref()).await?;
+        let wasm_bindgen = tools::get(
+            Application::WasmBindgen,
+            version.as_deref(),
+            self.cfg.accept_invalid_certs,
+        )
+        .await?;
 
         // Ensure our output dir is in place.
         let wasm_bindgen_name = Application::WasmBindgen.name();
@@ -507,7 +512,8 @@ impl RustApp {
         }
 
         let version = self.cfg.tools.wasm_opt.as_deref();
-        let wasm_opt = tools::get(Application::WasmOpt, version).await?;
+        let wasm_opt =
+            tools::get(Application::WasmOpt, version, self.cfg.accept_invalid_certs).await?;
 
         // Ensure our output dir is in place.
         let wasm_opt_name = Application::WasmOpt.name();

--- a/src/pipelines/sass.rs
+++ b/src/pipelines/sass.rs
@@ -62,7 +62,7 @@ impl Sass {
     async fn run(self) -> Result<TrunkAssetPipelineOutput> {
         // tracing::info!("downloading sass");
         let version = self.cfg.tools.sass.as_deref();
-        let sass = tools::get(Application::Sass, version).await?;
+        let sass = tools::get(Application::Sass, version, self.cfg.accept_invalid_certs).await?;
 
         // Compile the target SASS/SCSS file.
         let style = if self.cfg.release {

--- a/src/pipelines/tailwind_css.rs
+++ b/src/pipelines/tailwind_css.rs
@@ -60,7 +60,12 @@ impl TailwindCss {
     #[tracing::instrument(level = "trace", skip(self))]
     async fn run(self) -> Result<TrunkAssetPipelineOutput> {
         let version = self.cfg.tools.tailwindcss.as_deref();
-        let tailwind = tools::get(Application::TailwindCss, version).await?;
+        let tailwind = tools::get(
+            Application::TailwindCss,
+            version,
+            self.cfg.accept_invalid_certs,
+        )
+        .await?;
 
         // Compile the target tailwind css file.
         let style = if self.cfg.release { "--minify" } else { "" };


### PR DESCRIPTION
#579 

Add --accept-invalid-certs option to set reqwest danger_accept_invalid_certs option.

The SSL certificate cannot be verified in some special network environments. For eample, a proxy network is deployed with self-signed certificates in an enterprise.


<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [x ] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [ ] Updated `site` content with pertinent info (may not always apply).
- [x ] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
