### PR TITLE
Add two options to allow working behind corporate proxies

### DIFF
--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -86,6 +86,9 @@ pub struct ConfigOptsBuild {
     ///
     /// These values can only be provided via config file.
     pub pattern_params: Option<HashMap<String, String>>,
+    /// When desired, set a custom root certificate chain (same format as Cargo's config.toml http.cainfo)
+    #[serde(default)]
+    pub root_certificate: Option<String>,
 }
 
 /// Config options for the watch system.
@@ -305,6 +308,7 @@ impl ConfigOpts {
             pattern_script: cli.pattern_script,
             pattern_preload: cli.pattern_preload,
             pattern_params: cli.pattern_params,
+            root_certificate: cli.root_certificate,
         };
         let cfg_build = ConfigOpts {
             build: Some(opts),

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -88,11 +88,13 @@ pub struct ConfigOptsBuild {
     pub pattern_params: Option<HashMap<String, String>>,
     /// When desired, set a custom root certificate chain (same format as Cargo's config.toml http.cainfo)
     #[serde(default)]
+    #[arg(long)]
     pub root_certificate: Option<String>,
     /// Allows request to ignore certificate validation errors.
     /// 
     /// Can be useful when behind a corporate proxy.
     #[serde(default)]
+    #[arg(long)]
     pub accept_invalid_certs: Option<bool>,
 }
 

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -89,6 +89,11 @@ pub struct ConfigOptsBuild {
     /// When desired, set a custom root certificate chain (same format as Cargo's config.toml http.cainfo)
     #[serde(default)]
     pub root_certificate: Option<String>,
+    /// Allows request to ignore certificate validation errors.
+    /// 
+    /// Can be useful when behind a corporate proxy.
+    #[serde(default)]
+    pub accept_invalid_certs: Option<bool>,
 }
 
 /// Config options for the watch system.
@@ -309,6 +314,7 @@ impl ConfigOpts {
             pattern_preload: cli.pattern_preload,
             pattern_params: cli.pattern_params,
             root_certificate: cli.root_certificate,
+            accept_invalid_certs: cli.accept_invalid_certs,
         };
         let cfg_build = ConfigOpts {
             build: Some(opts),

--- a/src/config/rt.rs
+++ b/src/config/rt.rs
@@ -65,6 +65,10 @@ pub struct RtcBuild {
     pub pattern_params: Option<HashMap<String, String>>,
     /// Optional root certificate chain for use when downloading dependencies.
     pub root_certificate: Option<PathBuf>,
+    /// Sets if reqwest is allowed to ignore certificate validation errors (defaults to false).
+    /// 
+    /// **WARNING**: Setting this to true can make you vulnerable to man-in-the-middle attacks. Sometimes this is necessary when working behind corporate proxies.
+    pub accept_invalid_certs: Option<bool>,
 }
 
 impl RtcBuild {
@@ -139,6 +143,7 @@ impl RtcBuild {
             pattern_preload: opts.pattern_preload,
             pattern_params: opts.pattern_params,
             root_certificate: opts.root_certificate.map(PathBuf::from),
+            accept_invalid_certs: opts.accept_invalid_certs,
         })
     }
 
@@ -174,6 +179,7 @@ impl RtcBuild {
             pattern_preload: None,
             pattern_params: None,
             root_certificate: None,
+            accept_invalid_certs: None,
         })
     }
 }

--- a/src/config/rt.rs
+++ b/src/config/rt.rs
@@ -63,6 +63,8 @@ pub struct RtcBuild {
     /// Optional replacement parameters corresponding to the patterns provided in
     /// `pattern_script` and `pattern_preload`.
     pub pattern_params: Option<HashMap<String, String>>,
+    /// Optional root certificate chain for use when downloading dependencies.
+    pub root_certificate: Option<PathBuf>,
 }
 
 impl RtcBuild {
@@ -136,6 +138,7 @@ impl RtcBuild {
             pattern_script: opts.pattern_script,
             pattern_preload: opts.pattern_preload,
             pattern_params: opts.pattern_params,
+            root_certificate: opts.root_certificate.map(PathBuf::from),
         })
     }
 
@@ -170,6 +173,7 @@ impl RtcBuild {
             pattern_script: None,
             pattern_preload: None,
             pattern_params: None,
+            root_certificate: None,
         })
     }
 }

--- a/src/pipelines/rust.rs
+++ b/src/pipelines/rust.rs
@@ -365,7 +365,7 @@ impl RustApp {
         };
 
         let version = find_wasm_bindgen_version(&self.cfg.tools, &self.manifest);
-        let wasm_bindgen = tools::get(Application::WasmBindgen, version.as_deref(), &self.cfg.root_certificate).await?;
+        let wasm_bindgen = tools::get(Application::WasmBindgen, version.as_deref(), &self.cfg.root_certificate, self.cfg.accept_invalid_certs.unwrap_or(false)).await?;
 
         // Ensure our output dir is in place.
         let wasm_bindgen_name = Application::WasmBindgen.name();
@@ -507,7 +507,7 @@ impl RustApp {
         }
 
         let version = self.cfg.tools.wasm_opt.as_deref();
-        let wasm_opt = tools::get(Application::WasmOpt, version, &self.cfg.root_certificate).await?;
+        let wasm_opt = tools::get(Application::WasmOpt, version, &self.cfg.root_certificate, self.cfg.accept_invalid_certs.unwrap_or(false)).await?;
 
         // Ensure our output dir is in place.
         let wasm_opt_name = Application::WasmOpt.name();

--- a/src/pipelines/rust.rs
+++ b/src/pipelines/rust.rs
@@ -365,7 +365,7 @@ impl RustApp {
         };
 
         let version = find_wasm_bindgen_version(&self.cfg.tools, &self.manifest);
-        let wasm_bindgen = tools::get(Application::WasmBindgen, version.as_deref()).await?;
+        let wasm_bindgen = tools::get(Application::WasmBindgen, version.as_deref(), &self.cfg.root_certificate).await?;
 
         // Ensure our output dir is in place.
         let wasm_bindgen_name = Application::WasmBindgen.name();
@@ -507,7 +507,7 @@ impl RustApp {
         }
 
         let version = self.cfg.tools.wasm_opt.as_deref();
-        let wasm_opt = tools::get(Application::WasmOpt, version).await?;
+        let wasm_opt = tools::get(Application::WasmOpt, version, &self.cfg.root_certificate).await?;
 
         // Ensure our output dir is in place.
         let wasm_opt_name = Application::WasmOpt.name();

--- a/src/pipelines/sass.rs
+++ b/src/pipelines/sass.rs
@@ -62,7 +62,7 @@ impl Sass {
     async fn run(self) -> Result<TrunkAssetPipelineOutput> {
         // tracing::info!("downloading sass");
         let version = self.cfg.tools.sass.as_deref();
-        let sass = tools::get(Application::Sass, version).await?;
+        let sass = tools::get(Application::Sass, version, &self.cfg.root_certificate).await?;
 
         // Compile the target SASS/SCSS file.
         let style = if self.cfg.release {

--- a/src/pipelines/sass.rs
+++ b/src/pipelines/sass.rs
@@ -62,7 +62,7 @@ impl Sass {
     async fn run(self) -> Result<TrunkAssetPipelineOutput> {
         // tracing::info!("downloading sass");
         let version = self.cfg.tools.sass.as_deref();
-        let sass = tools::get(Application::Sass, version, &self.cfg.root_certificate).await?;
+        let sass = tools::get(Application::Sass, version, &self.cfg.root_certificate, self.cfg.accept_invalid_certs.unwrap_or(false)).await?;
 
         // Compile the target SASS/SCSS file.
         let style = if self.cfg.release {

--- a/src/pipelines/tailwind_css.rs
+++ b/src/pipelines/tailwind_css.rs
@@ -60,7 +60,7 @@ impl TailwindCss {
     #[tracing::instrument(level = "trace", skip(self))]
     async fn run(self) -> Result<TrunkAssetPipelineOutput> {
         let version = self.cfg.tools.tailwindcss.as_deref();
-        let tailwind = tools::get(Application::TailwindCss, version).await?;
+        let tailwind = tools::get(Application::TailwindCss, version, &self.cfg.root_certificate).await?;
 
         // Compile the target tailwind css file.
         let style = if self.cfg.release { "--minify" } else { "" };

--- a/src/pipelines/tailwind_css.rs
+++ b/src/pipelines/tailwind_css.rs
@@ -60,7 +60,7 @@ impl TailwindCss {
     #[tracing::instrument(level = "trace", skip(self))]
     async fn run(self) -> Result<TrunkAssetPipelineOutput> {
         let version = self.cfg.tools.tailwindcss.as_deref();
-        let tailwind = tools::get(Application::TailwindCss, version, &self.cfg.root_certificate).await?;
+        let tailwind = tools::get(Application::TailwindCss, version, &self.cfg.root_certificate, self.cfg.accept_invalid_certs.unwrap_or(false)).await?;
 
         // Compile the target tailwind css file.
         let style = if self.cfg.release { "--minify" } else { "" };


### PR DESCRIPTION
Add options `accept_invalid_certs` and `root_certificate` to allow functioning behind corporate vpn/proxy connections that use self-signed CA's.

**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [ ] Updated `site` content with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
