### PR TITLE
Remove top-level `await` in module to improve browser compatibility

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -45,11 +45,10 @@ The `index.scss` file may be empty but must exist.
     
 <script type="module">
 import init, * as bindings from '/my_program_name-905e0077a27c1ab6.js';
-const wasm = await init('/my_program_name-905e0077a27c1ab6_bg.wasm');
-
-window.wasmBindings = bindings;
-dispatchEvent(new CustomEvent("TrunkApplicationStarted", {detail: {wasm}}));
-
+await init('/my_program_name-905e0077a27c1ab6_bg.wasm').then(wasm => {
+  window.wasmBindings = bindings;
+  dispatchEvent(new CustomEvent("TrunkApplicationStarted", {detail: {wasm}}));
+});
 </script>
   <link rel="modulepreload" href="/my_program_name-905e0077a27c1ab6.js" crossorigin="anonymous" integrity="sha384-XtIBch5nbGDblQX/VKgj2jEZMDa5+UbPgVtEQp18GY63sZAFYf81ithX9iMSLbBn"><link rel="preload" href="/my_program_name-905e0077a27c1ab6_bg.wasm" crossorigin="anonymous" integrity="sha384-Mf9hhCJLbxzecZm30W8m15djd1Z1yamaa52XBF0TsvX0/qITABYRpsB5cVmy3lt/" as="fetch" type="application/wasm"></head>
 </html>

--- a/src/pipelines/rust/output.rs
+++ b/src/pipelines/rust/output.rs
@@ -145,10 +145,10 @@ dispatchEvent(new CustomEvent("TrunkApplicationStarted", {detail: {wasm}}));
                 r#"
 <script type="module"{nonce}>
 import init{import} from '{base}{js}';
-init({init_arg}).then(wasm => {
+init({init_arg}).then(wasm => {{
   {bind}
   {fire}
-});
+}});
 </script>"#,
                 init_arg = if init_with_object {
                     format!("{{ module_or_path: '{base}{wasm}' }}")
@@ -164,10 +164,10 @@ init({init_arg}).then(wasm => {
 import init{import} from '{base}{js}';
 import initializer from '{base}{initializer}';
 
-__trunkInitializer(init, '{base}{wasm}', {size}, initializer(), {init_with_object}).then(wasm => {
+__trunkInitializer(init, '{base}{wasm}', {size}, initializer(), {init_with_object}).then(wasm => {{
   {bind}
   {fire}
-});
+}});
 </script>"#,
                 init = include_str!("initializer.js"),
                 size = self.wasm_size,


### PR DESCRIPTION
Top-level await in a module is a compatibility bottle-neck for my app:
<img width="1441" height="470" alt="image" src="https://github.com/user-attachments/assets/5a3879e1-6481-4a8b-aa29-e9446d7f4a49" />
<img width="1440" height="605" alt="image" src="https://github.com/user-attachments/assets/409e83fc-7996-4d64-b596-84eb8412f633" />


With this PR, for example, I can run my app in Chrome 87 on my 2015 Macbook. Without this PR, I get a syntax error on that device. In general, this PR helps with browsers older than early 2021.

# Alternatives

Trunk could respect the `WasmBindgenTarget::NoModules` configuration option when generating HTML.