### PR TITLE
feat: allow assets to have absolute paths

### DIFF
--- a/src/pipelines/copy_dir.rs
+++ b/src/pipelines/copy_dir.rs
@@ -36,8 +36,7 @@ impl CopyDir {
         let href_attr = attrs.get(ATTR_HREF).context(
             r#"required attr `href` missing for <link data-trunk rel="copy-dir" .../> element"#,
         )?;
-        let mut path = PathBuf::new();
-        path.extend(href_attr.split('/'));
+        let mut path = PathBuf::from(href_attr.as_ref());
         if !path.is_absolute() {
             path = html_dir.join(path);
         }

--- a/src/pipelines/copy_file.rs
+++ b/src/pipelines/copy_file.rs
@@ -37,8 +37,7 @@ impl CopyFile {
         let href_attr = attrs.get(ATTR_HREF).context(
             r#"required attr `href` missing for <link data-trunk rel="copy-file" .../> element"#,
         )?;
-        let mut path = PathBuf::new();
-        path.extend(href_attr.split('/'));
+        let path = PathBuf::from(href_attr.as_ref());
         let asset = AssetFile::new(&html_dir, path).await?;
 
         let target_path = data_target_path(&attrs)?;

--- a/src/pipelines/css.rs
+++ b/src/pipelines/css.rs
@@ -46,8 +46,7 @@ impl Css {
         let href_attr = attrs.get(ATTR_HREF).context(
             r#"required attr `href` missing for <link data-trunk rel="css" .../> element"#,
         )?;
-        let mut path = PathBuf::new();
-        path.extend(href_attr.split('/'));
+        let path = PathBuf::from(href_attr.as_ref());
         let asset = AssetFile::new(&html_dir, path).await?;
 
         let integrity = IntegrityType::from_attrs(&attrs, &cfg)?;

--- a/src/pipelines/icon.rs
+++ b/src/pipelines/icon.rs
@@ -43,8 +43,7 @@ impl Icon {
         let href_attr = attrs.get(ATTR_HREF).context(
             r#"required attr `href` missing for <link data-trunk rel="icon" .../> element"#,
         )?;
-        let mut path = PathBuf::new();
-        path.extend(href_attr.split('/'));
+        let path = PathBuf::from(href_attr.as_ref());
         let asset = AssetFile::new(&html_dir, path).await?;
 
         let integrity = IntegrityType::from_attrs(&attrs, &cfg)?;

--- a/src/pipelines/inline.rs
+++ b/src/pipelines/inline.rs
@@ -36,9 +36,7 @@ impl Inline {
             r#"required attr `href` missing for <link data-trunk rel="inline" .../> element"#,
         )?;
 
-        let mut path = PathBuf::new();
-        path.extend(href_attr.split('/'));
-
+        let path = PathBuf::from(href_attr.as_ref());
         let asset = AssetFile::new(&html_dir, path).await?;
         let content_type =
             ContentType::from_attr_or_ext(attrs.get(ATTR_TYPE), asset.ext.as_deref())?;

--- a/src/pipelines/js.rs
+++ b/src/pipelines/js.rs
@@ -46,8 +46,7 @@ impl Js {
         let src_attr = attrs
             .get(ATTR_SRC)
             .context(r#"required attr `src` missing for <script data-trunk ...> element"#)?;
-        let mut path = PathBuf::new();
-        path.extend(src_attr.split('/'));
+        let path = PathBuf::from(src_attr.as_ref());
         let asset = AssetFile::new(&html_dir, path).await?;
 
         let integrity = IntegrityType::from_attrs(&attrs, &cfg)?;

--- a/src/pipelines/sass.rs
+++ b/src/pipelines/sass.rs
@@ -48,8 +48,7 @@ impl Sass {
         let href_attr = attrs.get(ATTR_HREF).context(
             r#"required attr `href` missing for <link data-trunk rel="sass|scss" .../> element"#,
         )?;
-        let mut path = PathBuf::new();
-        path.extend(href_attr.split('/'));
+        let path = PathBuf::from(href_attr.as_ref());
         let asset = AssetFile::new(&html_dir, path).await?;
         let use_inline = attrs.contains_key(ATTR_INLINE);
         let no_minify = attrs.contains_key(ATTR_NO_MINIFY);

--- a/src/pipelines/tailwind_css.rs
+++ b/src/pipelines/tailwind_css.rs
@@ -50,8 +50,7 @@ impl TailwindCss {
             r#"required attr `href` missing for <link data-trunk rel="tailwind-css" .../> element"#,
         )?;
         let tailwind_config = attrs.get(ATTR_CONFIG).map(|attr| &attr.value).cloned();
-        let mut path = PathBuf::new();
-        path.extend(href_attr.split('/'));
+        let path = PathBuf::from(href_attr.as_ref());
         let asset = AssetFile::new(&html_dir, path).await?;
         let use_inline = attrs.contains_key(ATTR_INLINE);
 

--- a/src/pipelines/tailwind_css_extra.rs
+++ b/src/pipelines/tailwind_css_extra.rs
@@ -50,8 +50,7 @@ impl TailwindCssExtra {
             r#"required attr `href` missing for <link data-trunk rel="tailwind-css-extra" .../> element"#,
         )?;
         let tailwind_config = attrs.get(ATTR_CONFIG).map(|attr| &attr.value).cloned();
-        let mut path = PathBuf::new();
-        path.extend(href_attr.split('/'));
+        let path = PathBuf::from(href_attr.as_ref());
         let asset = AssetFile::new(&html_dir, path).await?;
         let use_inline = attrs.contains_key(ATTR_INLINE);
 


### PR DESCRIPTION
exemple: `<link data-trunk data-target-path="images" rel="copy-dir" href="/tmp/my-images" />`

Closes #1045