### PR TITLE
feat: add `resolve_paths_from_workdir` option for relative path resolution

### DIFF
--- a/Trunk.toml
+++ b/Trunk.toml
@@ -32,6 +32,11 @@ no_sri = false
 # cargo_profile = "release-trunk"
 # Allow injecting a nonce attribute
 create_nonce = false
+# Relative paths in the HTML file (e.g., assets, scripts) are resolved
+# relative to the working directory (where `trunk` was invoked) instead of the
+# directory containing the `index.html` file.
+# Useful if the `index.html` file is located separately from the assets.
+resolve_paths_from_workdir = false
 
 [watch]
 # Paths to watch. The `build.target`'s parent folder is watched by default.

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -26,6 +26,7 @@
         "public_url": "/",
         "public_url_no_trailing_slash_fix": false,
         "release": false,
+        "resolve_paths_from_workdir": false,
         "target": "index.html"
       }
     },
@@ -220,6 +221,11 @@
         },
         "release": {
           "description": "Build in release mode [default: false]",
+          "type": "boolean",
+          "default": false
+        },
+        "resolve_paths_from_workdir": {
+          "description": "Relative paths in the HTML file (e.g., assets, scripts) are resolved\nrelative to the working directory (where `trunk` was invoked) instead of the\ndirectory containing the `index.html` file.\n\nUseful if the `index.html` file is located separately from the assets.",
           "type": "boolean",
           "default": false
         },

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -116,6 +116,15 @@ pub struct Build {
     #[arg(default_missing_value="true", num_args=0..=1)]
     pub allow_self_closing_script: Option<bool>,
 
+    /// Relative paths in the HTML file (e.g., assets, scripts) are resolved
+    /// relative to the working directory (where `trunk` was invoked) instead of the
+    /// directory containing the `index.html` file.
+    ///
+    /// Useful if the `index.html` file is located separately from the assets.
+    #[arg(long, env = "TRUNK_BUILD_RESOLVE_PATHS_FROM_WORKDIR")]
+    #[arg(default_missing_value="false", num_args=0..=1)]
+    pub resolve_paths_from_workdir: Option<bool>,
+
     // NOTE: flattened structures come last
     #[command(flatten)]
     pub core: super::core::Core,
@@ -149,6 +158,7 @@ impl Build {
             minify,
             no_sri,
             allow_self_closing_script,
+            resolve_paths_from_workdir,
             tools,
         } = self;
 
@@ -184,6 +194,8 @@ impl Build {
         config.build.no_sri = no_sri.unwrap_or(config.build.no_sri);
         config.build.allow_self_closing_script =
             allow_self_closing_script.unwrap_or(config.build.allow_self_closing_script);
+        config.build.resolve_paths_from_workdir =
+            resolve_paths_from_workdir.unwrap_or(config.build.resolve_paths_from_workdir);
 
         let config = core.apply_to(config)?;
         let config = tools.apply_to(config)?;

--- a/src/config/models/build.rs
+++ b/src/config/models/build.rs
@@ -160,6 +160,14 @@ pub struct Build {
     /// The placeholder which is used in the 'nonce' attribute.
     #[serde(default = "default::nonce_placeholder")]
     pub nonce_placeholder: String,
+
+    /// Relative paths in the HTML file (e.g., assets, scripts) are resolved
+    /// relative to the working directory (where `trunk` was invoked) instead of the
+    /// directory containing the `index.html` file.
+    ///
+    /// Useful if the `index.html` file is located separately from the assets.
+    #[serde(default)]
+    pub resolve_paths_from_workdir: bool,
 }
 
 fn string_or_vec<'de, T, D>(deserializer: D) -> Result<Vec<T>, D::Error>
@@ -233,6 +241,7 @@ impl Default for Build {
             allow_self_closing_script: false,
             create_nonce: false,
             nonce_placeholder: default::nonce_placeholder(),
+            resolve_paths_from_workdir: false,
         }
     }
 }

--- a/src/config/rt/build.rs
+++ b/src/config/rt/build.rs
@@ -95,6 +95,12 @@ pub struct RtcBuild {
     pub allow_self_closing_script: bool,
     /// When set, create nonce attributes with the option as placeholder
     pub create_nonce: Option<String>,
+    /// Relative paths in the HTML file (e.g., assets, scripts) are resolved
+    /// relative to the working directory (where `trunk` was invoked) instead of the
+    /// directory containing the `index.html` file.
+    ///
+    /// Useful if the `index.html` file is located separately from the assets.
+    pub resolve_paths_from_workdir: bool,
 }
 
 impl Deref for RtcBuild {
@@ -221,6 +227,7 @@ impl RtcBuild {
             no_sri: build.no_sri,
             allow_self_closing_script: build.allow_self_closing_script,
             create_nonce,
+            resolve_paths_from_workdir: build.resolve_paths_from_workdir,
         })
     }
 
@@ -265,6 +272,7 @@ impl RtcBuild {
             no_sri: false,
             allow_self_closing_script: false,
             create_nonce: None,
+            resolve_paths_from_workdir: false,
         })
     }
 

--- a/src/config/rt/watch.rs
+++ b/src/config/rt/watch.rs
@@ -98,6 +98,7 @@ impl RtcWatch {
 
         let Watch { watch, ignore } = config.watch.clone();
 
+        let resolve_paths_from_workdir = config.build.resolve_paths_from_workdir;
         let build = RtcBuild::new(config, build_opts)?;
 
         tracing::debug!("Disable error reporting: {no_error_reporting}");
@@ -115,10 +116,16 @@ impl RtcWatch {
             paths.push(canon_path);
         }
 
-        // If no watch paths were provided, then we default to the target HTML's parent dir.
+        // If no watch paths were provided, then we default to the target HTML's parent dir,
+        // or the current working directory.
         if paths.is_empty() {
-            paths.push(build.target_parent.clone());
+            paths.push(if resolve_paths_from_workdir {
+                build.working_directory.clone()
+            } else {
+                build.target_parent.clone()
+            });
         }
+        tracing::debug!("Watching for changes in paths {:?}", paths);
 
         let mut ignored_paths = GlobMatcher::new();
 

--- a/src/pipelines/html.rs
+++ b/src/pipelines/html.rs
@@ -56,12 +56,14 @@ impl HtmlPipeline {
             .target
             .canonicalize()
             .context("failed to get canonical path of target HTML file")?;
-        let target_html_dir = Arc::new(
+        let target_html_dir = Arc::new(if cfg.resolve_paths_from_workdir {
+            cfg.working_directory.clone()
+        } else {
             target_html_path
                 .parent()
                 .context("failed to determine parent dir of target HTML file")?
-                .to_owned(),
-        );
+                .to_owned()
+        });
 
         Ok(Self {
             cfg,


### PR DESCRIPTION
Closes #1049

Adds new flag `resolve_paths_from_workdir`, available on the CLI, Trunk.toml, and the `RESOLVE_PATHS_FROM_WORKDIR` environment variable.

I followed the instructions in the contributing.md file, I hope I did not forget anything.
