### PR TITLE
fix: better support of NO_COLOR specification

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod watch;
 mod ws;
 
 use anyhow::{Context, Result};
+use clap::builder::FalseyValueParser;
 use clap::{ArgAction, Parser, Subcommand, ValueEnum};
 use common::STARTING;
 use std::io::IsTerminal;
@@ -142,7 +143,7 @@ struct Trunk {
     pub color: ColorMode,
 
     /// Support for `NO_COLOR` environment variable
-    #[arg(long, env = "NO_COLOR", global(true))]
+    #[arg(long, env = "NO_COLOR", global(true), value_parser = FalseyValueParser::new())]
     pub no_color: bool,
 }
 


### PR DESCRIPTION
This updates `NO_COLOR` env var handling to accept arbitrary string values instead of only boolean-like values.

This better supports the https://no-color.org/ convention: users can set `NO_COLOR=1`, `NO_COLOR=true`, or any other marker value and Trunk will accept it as a request to disable color.

## Behavior

Now disables color:

```
NO_COLOR=1 trunk build
NO_COLOR=true trunk build
NO_COLOR=yes trunk build
NO_COLOR=please trunk build
NO_COLOR=anything trunk build
```

Does not disable color:

```
NO_COLOR=0 trunk build
NO_COLOR=false trunk build
NO_COLOR=f trunk build
NO_COLOR=no trunk build
NO_COLOR=n trunk build
NO_COLOR=off trunk build
NO_COLOR= trunk build
```

## What Has Not Changed

- `--no-color` is still a flag, not a valued option.
- `--no-color` still takes precedence over `NO_COLOR` env var.
- `--no-color=false` is still invalid.
- `--color <auto|always|never>` behavior is unchanged.
- `--color` still conflicts with `--no-color`.

## Difference From no-color.org

https://no-color.org specifies that any present, non-empty `NO_COLOR` env var value should disable color regardless of value.

This change makes trunk accept arbitrary marker values, but it intentionally keeps clap’s falsey parsing behavior. That means `0`, `false`, `f`, `no`, `n`, and `off` (case-insensitive) do not disable color; any other non-empty value does.

Fixes #1065