### PR TITLE
docs: fix getting started scss path

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -28,13 +28,13 @@ Trunk uses a source HTML file to drive all asset building and bundling. Trunk al
 ```html
 <html>
   <head>
-    <link data-trunk rel="scss" href="path/to/index.scss"/>
+    <link data-trunk rel="scss" href="index.scss"/>
     <link data-trunk rel="rust"/>
   </head>
 </html>
 ```
 
-The `index.scss` file may be empty but must exist.
+The `index.scss` file referenced above may be empty but must exist next to `index.html`.
 
 `trunk build` will produce the following HTML at `dist/index.html`, along with the compiled scss, WASM & the JS loader for the WASM:
 


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Update the getting-started HTML example to reference `index.scss` instead of placeholder `path/to/index.scss`.
- Clarify that the referenced `index.scss` file may be empty but must exist next to `index.html`.

Fixes #958

## Test plan
- `git diff --check`
- Searched the site content to verify the stale `path/to/index.scss` example was removed.
- `zola check` was not run locally because `zola` is not installed in this environment.
