### PR TITLE
docs: document minification backends

### DIFF
--- a/guide/src/assets/minification.md
+++ b/guide/src/assets/minification.md
@@ -5,6 +5,18 @@ Trunk supports minifying assets. This is disabled by default and can be controll
 In any case, Trunk does not perform minification itself, but delegates the process to dependencies which do the actual
 implementation. In cases where minification breaks things, it will, most likely, be an issue with that dependency.
 
+The current backends are:
+
+- HTML: [`minify-html`](https://github.com/wilsonzlin/minify-html), including inline CSS and JavaScript in HTML.
+- CSS assets: [`lightningcss`](https://github.com/parcel-bundler/lightningcss).
+- JavaScript assets, ES modules, and generated Rust/WASM loader snippets: [`swc`](https://swc.rs/).
+- SASS/SCSS assets: the configured `sass`/`dart-sass` tool, using compressed output when minification is enabled.
+- Tailwind CSS assets: the configured `tailwindcss` tool, using its `--minify` flag.
+- PNG icons: [`oxipng`](https://github.com/shssoichiro/oxipng); other icon/image formats are copied unchanged.
+
+If a backend cannot parse or minify an individual CSS or JavaScript asset, Trunk logs a warning and keeps the original
+asset bytes for that file.
+
 Starting with Trunk 0.20.0, minification is disabled by default. It can be turned on from the command line using the
 `--minify` (or `-M`) switch. Alternatively, it can be controlled using the `build.minify` field in the `Trunk.toml`
 file. The value of this field is an enum, with the following possible values: `never` (default, never minify),


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Document the current minification backends used by Trunk for HTML, CSS, JavaScript, SASS/SCSS, Tailwind CSS, and PNG icons.
- Note that Trunk keeps original CSS/JavaScript bytes when those minifiers cannot parse or minify a specific asset.

Fixes #810

## Test plan
- `git diff --check`
- Searched the minification guide for the new backend entries.
- `mdbook test guide` was not run locally because `mdbook` is not installed in this environment.
