### PR TITLE
docs: clarify relative public_url usage

### DIFF
--- a/guide/src/configuration/index.md
+++ b/guide/src/configuration/index.md
@@ -131,6 +131,15 @@ minify = "never"            # Control minification: can be one of: never, on_rel
 no_sri = false              # Allow disabling sub-resource integrity (SRI)
 ```
 
+
+`public_url` may be an absolute path such as `/my-app/` or a relative path such as `./`. Use a relative value when the same build output can be served from different prefixes, for example GitLab Pages projects that may be hosted either at a project subpath or at a dedicated domain:
+
+```sh
+trunk build --release --public-url='./'
+```
+
+The equivalent configuration value is `public_url = "./"` in the `[build]` section.
+
 ## Watch section
 
 Trunk has built-in support for watching for source file changes, which triggers


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Clarify that `build.public_url` can be a relative value such as `./`.
- Add a `trunk build --release --public-url='./'` example for deployments that may be served from different prefixes, including GitLab Pages.
- Show the equivalent `[build]` configuration value.

Fixes #997

## Test plan
- `git diff --check`
- Source-level docs check confirming the new `--public-url='./'`, `public_url = "./"`, and GitLab Pages guidance are present.
- `mdbook test guide` was not run locally because `mdbook` is not installed in this environment.
